### PR TITLE
Make sure $post_status gets converted to plain array in ES query

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1184,7 +1184,7 @@ class Post extends Indexable {
 
 				$filter['bool']['must'][] = array(
 					$terms_map_name => array(
-						'post_status' => $post_status,
+						'post_status' => array_values( $post_status ),
 					),
 				);
 


### PR DESCRIPTION
### Description of the Change

When passing in post statuses as filters for ES queries, ElasticPress will return an error if the array is an associative array instead of a plain array.
In other parts of the module, `array_values()` is used to normalize the hash; we have added this conversion for safety when `post_status` is explicitly passed in, too.
10up folks acknowledged the issue but said they would rather refactor that code. It won't happen anytime soon so we are just going to live with this small change for now.

