### PR TITLE
Fix post_status flattening

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1211,6 +1211,8 @@ class Post extends Indexable {
 			// should NEVER be "any" but just in case
 			if ( 'any' !== $args['post_status'] ) {
 				$post_status    = (array) ( is_string( $args['post_status'] ) ? explode( ',', $args['post_status'] ) : $args['post_status'] );
+				# Flatten out the array
+				$post_status    = array_values( $post_status )
 				$post_status    = array_map( 'trim', $post_status );
 				$terms_map_name = 'terms';
 				if ( count( $post_status ) < 2 ) {
@@ -1220,7 +1222,7 @@ class Post extends Indexable {
 
 				$filter['bool']['must'][] = array(
 					$terms_map_name => array(
-						'post_status' => array_values( $post_status ),
+						'post_status' => $post_status,
 					),
 				);
 


### PR DESCRIPTION
`$post_status` array has to be flattened if it's an associative array, but as we did that before this PR, it caused sometimes errors because the array was already converted to `string` before our conversion.

This PR should fix it.