### PR TITLE
Re-index posts on term change

### DIFF
--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -1,0 +1,107 @@
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR="${WP_TESTS_DIR-/tmp/wordpress-tests-lib}/"
+WP_CORE_DIR="${WP_CORE_DIR-/tmp/wordpress}/"
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$WP_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$WP_VERSION"
+fi
+
+echo $WP_VERSION
+
+set -ex
+
+# Footle around to remove any trailing slashes, and then add
+# them back in again.
+# We're going to install WordPress and the WordPress test lib
+# to version specific directories, for greater control locally
+shopt -s extglob;
+WP_TESTS_DIR_ACTUAL="${WP_TESTS_DIR%%+(/)}-${WP_VERSION}/"
+WP_CORE_DIR_ACTUAL="${WP_CORE_DIR%%+(/)}-${WP_VERSION}/"
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR_ACTUAL ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR_ACTUAL
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR_ACTUAL
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
+	fi
+
+	cd $WP_TESTS_DIR_ACTUAL
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	fi
+
+}
+
+install_wp
+install_test_suite
+
+# Create a symbolic link to the version specific directories
+# from a generic location
+rm -rf "${WP_CORE_DIR%%+(/)}"
+rm -rf "${WP_TESTS_DIR%%+(/)}"
+ln -s "${WP_CORE_DIR_ACTUAL%%+(/)}" "${WP_CORE_DIR%%+(/)}"
+ln -s "${WP_TESTS_DIR_ACTUAL%%+(/)}" "${WP_TESTS_DIR%%+(/)}"
+

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Note: you can pass in additional phpunit args
+# Test a specific file: ./bin/phpunit-docker.sh tests/path/to/test.php
+# Stop on failures: ./bin/phpunit-docker.sh --stop-on-failure
+# etc.
+
+WP_VERSION=${2-latest}
+WP_MULTISITE=${3-0}
+
+echo "--------------"
+echo "Will test with WP_VERSION=$WP_VERSION and WP_MULTISITE=$WP_MULTISITE"
+echo "--------------"
+echo
+
+MYSQL_ROOT_PASSWORD='wordpress'
+docker network create tests
+docker pull docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+db=$(docker run --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+es=$(docker run --network tests --name es -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -d docker.elastic.co/elasticsearch/elasticsearch:7.5.2)
+function cleanup() {
+	docker rm -f $db
+	docker rm -f $es
+	docker network rm tests
+}
+trap cleanup EXIT
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "db" "$WP_VERSION")
+
+## Ensure there's a database connection for the rest of the steps
+until docker exec -it $db mysql -u root -h db --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
+	echo "Waiting for database connection..."
+	sleep 5
+done
+
+docker run \
+ 	--network tests \
+	-e WP_MULTISITE="$WP_MULTISITE" \
+	-e EP_HOST="http://es:9200" \
+	-v $(pwd):/app \
+	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
+	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
+	--rm phpunit/phpunit \
+	--bootstrap /app/tests/php/bootstrap.php "$@"

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -358,7 +358,7 @@ class Post extends Indexable {
 
 	/**
 	 * Get an array of taxonomies that are indexable for the given post
-	 * 
+	 *
 	 * @param WP_Post $post Post object
 	 * @return array Array of taxonomy slugs that should be indexed
 	 */
@@ -371,7 +371,7 @@ class Post extends Indexable {
 				$selected_taxonomies[] = $taxonomy;
 			}
 		}
-		
+
 		/**
 		 * Filter taxonomies to be synced with post
 		 *

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -357,13 +357,12 @@ class Post extends Indexable {
 	}
 
 	/**
-	 * Prepare terms to send to ES.
-	 *
+	 * Get an array of taxonomies that are indexable for the given post
+	 * 
 	 * @param WP_Post $post Post object
-	 * @since 0.1.0
-	 * @return array
+	 * @return array Array of taxonomy slugs that should be indexed
 	 */
-	private function prepare_terms( $post ) {
+	public function get_indexable_post_taxonomies( $post ) {
 		$taxonomies          = get_object_taxonomies( $post->post_type, 'objects' );
 		$selected_taxonomies = [];
 
@@ -372,7 +371,7 @@ class Post extends Indexable {
 				$selected_taxonomies[] = $taxonomy;
 			}
 		}
-
+		
 		/**
 		 * Filter taxonomies to be synced with post
 		 *
@@ -382,6 +381,19 @@ class Post extends Indexable {
 		 * @return  {array} New taxonomies
 		 */
 		$selected_taxonomies = apply_filters( 'ep_sync_taxonomies', $selected_taxonomies, $post );
+
+		return $selected_taxonomies;
+	}
+
+	/**
+	 * Prepare terms to send to ES.
+	 *
+	 * @param WP_Post $post Post object
+	 * @since 0.1.0
+	 * @return array
+	 */
+	private function prepare_terms( $post ) {
+		$selected_taxonomies = $this->get_indexable_post_taxonomies( $post );
 
 		if ( empty( $selected_taxonomies ) ) {
 			return [];

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1224,7 +1224,7 @@ class Post extends Indexable {
 			if ( 'any' !== $args['post_status'] ) {
 				$post_status    = (array) ( is_string( $args['post_status'] ) ? explode( ',', $args['post_status'] ) : $args['post_status'] );
 				# Flatten out the array
-				$post_status    = array_values( $post_status )
+				$post_status    = array_values( $post_status );
 				$post_status    = array_map( 'trim', $post_status );
 				$terms_map_name = 'terms';
 				if ( count( $post_status ) < 2 ) {

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -130,7 +130,9 @@ class SyncManager extends SyncManagerAbstract {
 			// Only re-index if the taxonomy is indexed for this post
 			$indexable_taxonomies = $indexable->get_indexable_post_taxonomies( $post );
 
-			if ( ! in_array( $taxonomy, $indexable_taxonomies ) ) {
+			$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
+
+			if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
 				return;
 			}
 

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -99,9 +99,9 @@ class SyncManager extends SyncManagerAbstract {
 	/**
 	 * When a term is updated, re-index all posts attached to that term
 	 *
-	 * @param  int       $term_id Term id.
-	 * @param  int       $tt_id Term Taxonomy id.
-	 * @param  string    $taxonomy Taxonomy name.
+	 * @param  int    $term_id Term id.
+	 * @param  int    $tt_id Term Taxonomy id.
+	 * @param  string $taxonomy Taxonomy name.
 	 * @since  3.5
 	 */
 	public function action_edited_term( $term_id, $tt_id, $taxonomy ) {
@@ -122,7 +122,7 @@ class SyncManager extends SyncManagerAbstract {
 		$indexable = Indexables::factory()->get( 'post' );
 
 		// Add all of them to the queue
-		foreach( $object_ids as $post_id ) {
+		foreach ( $object_ids as $post_id ) {
 			$post_type = get_post_type( $post_id );
 
 			$post = get_post( $post_id );
@@ -170,12 +170,18 @@ class SyncManager extends SyncManagerAbstract {
 
 	/**
 	 * When a post's terms are changed, re-index
-	 * 
+	 *
 	 * This catches term deletions via wp_delete_term(), because that function internally loops over all attached objects
 	 * and updates their terms. It will also end up firing whenever set_object_terms is called, but the queue will de-duplicate
 	 * multiple instances per post
 	 *
 	 * @see set_object_terms
+	 * @param int    $object_id  Object ID.
+	 * @param array  $terms      An array of object terms.
+	 * @param array  $tt_ids     An array of term taxonomy IDs.
+	 * @param string $taxonomy   Taxonomy slug.
+	 * @param bool   $append     Whether to append new terms to the old terms.
+	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
 	 * @since  3.5
 	 */
 	public function action_set_object_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -194,7 +194,9 @@ class SyncManager extends SyncManagerAbstract {
 		// Only re-index if the taxonomy is indexed for this post
 		$indexable_taxonomies = $indexable->get_indexable_post_taxonomies( $post );
 
-		if ( ! in_array( $taxonomy, $indexable_taxonomies ) ) {
+		$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
+
+		if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
 			return;
 		}
 

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -289,7 +289,7 @@ class TestPost extends BaseTestCase {
 		add_filter( 'ep_post_sync_args', array( $this, 'filter_post_sync_args' ), 10, 1 );
 
 		// Update the term
-		wp_update_term( $term['term_id'], 'category', array( 'slug' => 'new-slug' ) );
+		wp_update_term( $term['term_id'], 'category', array( 'slug' => 'new-slug', 'name' => 'New Name' ) );
 
 		$this->applied_filters = array();
 
@@ -301,7 +301,8 @@ class TestPost extends BaseTestCase {
 		// Check if new term slug was synced
 		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 
-		$this->assertTrue( 'new-slug', $post['terms']['post_category'][ 0 ]['slug'] );
+		$this->assertEquals( 'new-slug', $post['terms']['category'][ 0 ]['slug'] );
+		$this->assertEquals( 'New Name', $post['terms']['category'][ 0 ]['name'] );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -291,7 +291,9 @@ class TestPost extends BaseTestCase {
 		// Update the term
 		wp_update_term( $term['term_id'], 'category', array( 'slug' => 'new-slug' ) );
 
-		ElasticPress\Elasticsearch::factory()->refresh_indices();
+		$this->applied_filters = array();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->index_sync_queue();
 
 		// Check if ES post sync filter has been triggered
 		$this->assertTrue( ! empty( $this->applied_filters['ep_post_sync_args'] ) );

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -306,6 +306,57 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Make sure that when terms associated with a post are deleted that the posts are reindexed
+	 *
+	 * @since 3.5
+	 * @group post
+	 */
+	public function testPostTermSyncOnSetObjectTerms() {
+		$term = wp_insert_term( 'Test Tag', 'post_tag', array( 'slug' => 'test-tag' ) );
+
+		$post_id = Functions\create_and_sync_post(
+			array(
+				'tags_input' => array( $term['term_id'] ),
+			)
+		);
+
+		$post_id_two = Functions\create_and_sync_post(
+			array(
+				'tags_input' => array( $term['term_id'] ),
+			)
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		// Double check that our post is associated with this term (otherwise the test isn't doing anything)
+		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+		$post_two = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id_two );
+
+		$this->assertEquals( $term['term_id'], $post['terms']['post_tag'][ 0 ]['term_id'] );
+		$this->assertEquals( $term['term_id'], $post_two['terms']['post_tag'][ 0 ]['term_id'] );
+
+		add_filter( 'ep_post_sync_args', array( $this, 'filter_post_sync_args' ), 10, 1 );
+
+		// Delete the term
+		wp_delete_term( $term['term_id'], 'post_tag' );
+
+		$this->applied_filters = array();
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->index_sync_queue();
+
+		// Check if ES post sync filter has been triggered
+		$this->assertTrue( ! empty( $this->applied_filters['ep_post_sync_args'] ) );
+
+		// Check if new term slug was synced
+		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+		$post_two = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id_two );
+
+		// And the post documents no longer have any tags
+		$this->assertArrayNotHasKey( 'post_tag', $post['terms'] );
+		$this->assertArrayNotHasKey( 'post_tag', $post_two['terms'] );
+	}
+
+	/**
 	 * Make sure proper non-hierarchical taxonomies are synced with post when ep_sync_terms_allow_hierarchy is
 	 * set to false.
 	 *

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -270,6 +270,39 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Make sure that when terms associated with a post are updated that the post is reindexed
+	 *
+	 * @since 3.5
+	 * @group post
+	 */
+	public function testPostTermSyncOnTermEdited() {
+		$term = wp_insert_term( 'Test Category', 'category', array( 'slug' => 'test-category' ) );
+
+		$post_id = Functions\create_and_sync_post(
+			array(
+				'post_category' => array( $term['term_id'] ),
+			)
+		);
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		add_filter( 'ep_post_sync_args', array( $this, 'filter_post_sync_args' ), 10, 1 );
+
+		// Update the term
+		wp_update_term( $term['term_id'], 'category', array( 'slug' => 'new-slug' ) );
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		// Check if ES post sync filter has been triggered
+		$this->assertTrue( ! empty( $this->applied_filters['ep_post_sync_args'] ) );
+
+		// Check if new term slug was synced
+		$post = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+
+		$this->assertTrue( 'new-slug', $post['terms']['post_category'][ 0 ]['slug'] );
+	}
+
+	/**
 	 * Make sure proper non-hierarchical taxonomies are synced with post.
 	 *
 	 * @group post


### PR DESCRIPTION
Hooks into term edit and delete actions to re-index the posts attached to those terms.

The commits are kinda funky b/c I accidentally pushed to `develop` at first).

This runs the risk of being pretty slow (on terms with many associated posts)...but I think we have to go this route for consistency (it checks that the post _should_ be indexed before queuing it, matching the behavior of other functions in the SyncManager). Without the extra checking, we would risk indexing posts that we shouldn't.