### PR TITLE
Add scripts for phpunit with docker

### DIFF
--- a/bin/download-wp-tests.sh
+++ b/bin/download-wp-tests.sh
@@ -1,0 +1,107 @@
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR="${WP_TESTS_DIR-/tmp/wordpress-tests-lib}/"
+WP_CORE_DIR="${WP_CORE_DIR-/tmp/wordpress}/"
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$WP_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$WP_VERSION"
+fi
+
+echo $WP_VERSION
+
+set -ex
+
+# Footle around to remove any trailing slashes, and then add
+# them back in again.
+# We're going to install WordPress and the WordPress test lib
+# to version specific directories, for greater control locally
+shopt -s extglob;
+WP_TESTS_DIR_ACTUAL="${WP_TESTS_DIR%%+(/)}-${WP_VERSION}/"
+WP_CORE_DIR_ACTUAL="${WP_CORE_DIR%%+(/)}-${WP_VERSION}/"
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR_ACTUAL ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR_ACTUAL
+
+	if [ $WP_VERSION == 'latest' ]; then
+		local ARCHIVE_NAME='latest'
+	else
+		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	fi
+
+	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR_ACTUAL
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR_ACTUAL/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR_ACTUAL ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR_ACTUAL
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR_ACTUAL/includes
+		svn co --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR_ACTUAL/data
+	fi
+
+	cd $WP_TESTS_DIR_ACTUAL
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR_ACTUAL"/wp-tests-config.php
+	fi
+
+}
+
+install_wp
+install_test_suite
+
+# Create a symbolic link to the version specific directories
+# from a generic location
+rm -rf "${WP_CORE_DIR%%+(/)}"
+rm -rf "${WP_TESTS_DIR%%+(/)}"
+ln -s "${WP_CORE_DIR_ACTUAL%%+(/)}" "${WP_CORE_DIR%%+(/)}"
+ln -s "${WP_TESTS_DIR_ACTUAL%%+(/)}" "${WP_TESTS_DIR%%+(/)}"
+

--- a/bin/phpunit-docker.sh
+++ b/bin/phpunit-docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Note: you can pass in additional phpunit args
+# Test a specific file: ./bin/phpunit-docker.sh tests/path/to/test.php
+# Stop on failures: ./bin/phpunit-docker.sh --stop-on-failure
+# etc.
+
+WP_VERSION=${2-latest}
+WP_MULTISITE=${3-0}
+
+echo "--------------"
+echo "Will test with WP_VERSION=$WP_VERSION and WP_MULTISITE=$WP_MULTISITE"
+echo "--------------"
+echo
+
+MYSQL_ROOT_PASSWORD='wordpress'
+docker network create tests
+docker pull docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+db=$(docker run --network tests --name db -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD -d mariadb)
+es=$(docker run --network tests --name es -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -d docker.elastic.co/elasticsearch/elasticsearch:7.5.2)
+function cleanup() {
+	docker rm -f $db
+	docker rm -f $es
+	docker network rm tests
+}
+trap cleanup EXIT
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+WP_VERSION=$($DIR/download-wp-tests.sh wordpress_test root "$MYSQL_ROOT_PASSWORD" "db" "$WP_VERSION")
+
+## Ensure there's a database connection for the rest of the steps
+until docker exec -it $db mysql -u root -h db --password="wordpress" -e 'CREATE DATABASE wordpress_test' > /dev/null; do
+	echo "Waiting for database connection..."
+	sleep 5
+done
+
+docker run \
+ 	--network tests \
+	-e WP_MULTISITE="$WP_MULTISITE" \
+	-e EP_HOST="http://es:9200" \
+	-v $(pwd):/app \
+	-v /tmp/wordpress-tests-lib-$WP_VERSION:/tmp/wordpress-tests-lib \
+	-v /tmp/wordpress-$WP_VERSION:/tmp/wordpress \
+	--rm phpunit/phpunit \
+	--bootstrap /app/tests/php/bootstrap.php "$@"

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1212,7 +1212,7 @@ class Post extends Indexable {
 			if ( 'any' !== $args['post_status'] ) {
 				$post_status    = (array) ( is_string( $args['post_status'] ) ? explode( ',', $args['post_status'] ) : $args['post_status'] );
 				# Flatten out the array
-				$post_status    = array_values( $post_status )
+				$post_status    = array_values( $post_status );
 				$post_status    = array_map( 'trim', $post_status );
 				$terms_map_name = 'terms';
 				if ( count( $post_status ) < 2 ) {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1211,7 +1211,7 @@ class Post extends Indexable {
 			// should NEVER be "any" but just in case
 			if ( 'any' !== $args['post_status'] ) {
 				$post_status    = (array) ( is_string( $args['post_status'] ) ? explode( ',', $args['post_status'] ) : $args['post_status'] );
-				# Flatten out the array
+				// Flatten out the array
 				$post_status    = array_values( $post_status );
 				$post_status    = array_map( 'trim', $post_status );
 				$terms_map_name = 'terms';

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1184,7 +1184,7 @@ class Post extends Indexable {
 
 				$filter['bool']['must'][] = array(
 					$terms_map_name => array(
-						'post_status' => $post_status,
+						'post_status' => array_values( $post_status ),
 					),
 				);
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1175,6 +1175,8 @@ class Post extends Indexable {
 			// should NEVER be "any" but just in case
 			if ( 'any' !== $args['post_status'] ) {
 				$post_status    = (array) ( is_string( $args['post_status'] ) ? explode( ',', $args['post_status'] ) : $args['post_status'] );
+				# Flatten out the array
+				$post_status    = array_values( $post_status )
 				$post_status    = array_map( 'trim', $post_status );
 				$terms_map_name = 'terms';
 				if ( count( $post_status ) < 2 ) {
@@ -1184,7 +1186,7 @@ class Post extends Indexable {
 
 				$filter['bool']['must'][] = array(
 					$terms_map_name => array(
-						'post_status' => array_values( $post_status ),
+						'post_status' => $post_status,
 					),
 				);
 


### PR DESCRIPTION
Adds `./bin/phpunit-docker.sh` to run the test suite locally via Docker. Includes a local ES instance.

Adapted from https://github.com/Automattic/vip-go-mu-plugins/blob/master/bin/phpunit-docker.sh

Testing
========

To test, simply run `./bin/phpunit-docker.sh`