### PR TITLE
Add multi get functions

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -601,7 +601,7 @@ class Elasticsearch {
 	 * Get multiple documents from Elasticsearch given an array of ids
 	 *
 	 * @param  string $index Index name.
-	 * @param  array  $document_id Array of document ids to get.
+	 * @param  array  $document_ids Array of document ids to get.
 	 * @since  3.5
 	 * @return boolean|array
 	 */

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -598,6 +598,40 @@ class Elasticsearch {
 	}
 
 	/**
+	 * Get multiple documents from Elasticsearch given an array of ids
+	 *
+	 * @param  string $index Index name.
+	 * @param  array  $document_id Array of document ids to get.
+	 * @since  3.5
+	 * @return boolean|array
+	 */
+	public function get_documents( $index, $document_ids ) {
+		$path = $index . '/_doc/_mget';
+
+		$request_args = [ 'method' => 'GET' ];
+
+		$request_body = array(
+			'docs' => $document_ids,
+		);
+
+		$request = $this->remote_request( $path, $request_args, array(
+			'body' => $request_body,
+		), 'get' );
+
+		if ( ! is_wp_error( $request ) ) {
+			$response_body = wp_remote_retrieve_body( $request );
+
+			$response = json_decode( $response_body, true );
+
+			if ( is_array( $response[ 'docs' ] ) ) {
+				return wp_list_pluck( $response[ 'docs' ], '_source' );
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Delete the network alias.
 	 *
 	 * Network aliases are used to query documents across blogs in a network.

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -619,27 +619,27 @@ class Elasticsearch {
 
 		$request = $this->remote_request( $path, $request_args, [], 'post' );
 
-		if ( ! is_wp_error( $request ) ) {
-			$response_body = wp_remote_retrieve_body( $request );
+		if ( is_wp_error( $request ) ) {
+			return false;
+		}
+		
+		$response_body = wp_remote_retrieve_body( $request );
 
-			$response = json_decode( $response_body, true );
+		$response = json_decode( $response_body, true );
 
-			$docs = [];
+		$docs = [];
 
-			if ( is_array( $response['docs'] ) ) {
-				foreach ( $response['docs'] as $doc ) {
-					if ( ! empty( $doc['exists'] ) || ! empty( $doc['found'] ) ) {
-						$docs[] = $doc['_source'];
-					} else {
-						$docs[] = null;
-					}
+		if ( is_array( $response['docs'] ) ) {
+			foreach ( $response['docs'] as $doc ) {
+				if ( ! empty( $doc['exists'] ) || ! empty( $doc['found'] ) ) {
+					$docs[] = $doc['_source'];
+				} else {
+					$docs[] = null;
 				}
 			}
-
-			return $docs;
 		}
 
-		return false;
+		return $docs;
 	}
 
 	/**
@@ -1343,4 +1343,3 @@ class Elasticsearch {
 	}
 
 }
-

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -198,6 +198,17 @@ abstract class Indexable {
 	}
 
 	/**
+	 * Get objects within the indexable
+	 *
+	 * @param  int $object_ids Array of object ids to get.
+	 * @since  3.0
+	 * @return boolean|array
+	 */
+	public function multi_get( $object_ids ) {
+		return Elasticsearch::factory()->get_documents( $this->get_index_name(), $object_ids );
+	}
+
+	/**
 	 * Delete an index within the indexable
 	 *
 	 * @param  int $blog_id `null` means current blog.


### PR DESCRIPTION
Adds functions for retrieving multiple documents at once, to compliment the existing functions for single document retrieval.

This can be used to grab a batch of documents to improve performance when retrieving large numbers of documents is necessary.