### PR TITLE
Allow query integration during indexing with a filter

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -35,7 +35,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Ensure that we are currently allowing ElasticPress to override the normal WP_Query
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_indexing() && ! apply_filters( 'ep_enable_query_integration_during_indexing', false, $this ) ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/Term/QueryIntegration.php
+++ b/includes/classes/Indexable/Term/QueryIntegration.php
@@ -28,7 +28,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Check if we are currently indexing
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_indexing() && ! apply_filters( 'ep_enable_query_integration_during_indexing', false, $this ) ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/User/QueryIntegration.php
+++ b/includes/classes/Indexable/User/QueryIntegration.php
@@ -28,7 +28,7 @@ class QueryIntegration {
 	 */
 	public function __construct() {
 		// Ensure that we are currently allowing ElasticPress to override the normal WP_Query
-		if ( Utils\is_indexing() ) {
+		if ( Utils\is_indexing() && ! apply_filters( 'ep_enable_query_integration_during_indexing', false, $this ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Previously, query integration was not possible while indexing was ongoing - this makes it optional with a filter (defaults to `false`, which is the current behavior).