### PR TITLE
Un-queue trashed posts

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -292,6 +292,9 @@ class SyncManager extends SyncManagerAbstract {
 		do_action( 'ep_delete_post', $post_id );
 
 		Indexables::factory()->get( 'post' )->delete( $post_id, false );
+
+		// Ensure that the post isn't queued for syncing (could have happened due to meta or other changes in same request)
+		$this->remove_from_queue( $post_id );
 	}
 
 	/**

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -82,6 +82,33 @@ abstract class SyncManager {
 	}
 
 	/**
+	 * Remove an object from the sync queue.
+	 *
+	 * @param  id $object_id object ID to remove from the queue
+	 * @since  3.5
+	 * @return boolean
+	 */
+	public function remove_from_queue( $object_id ) {
+		if ( ! is_numeric( $object_id ) ) {
+			return false;
+		}
+
+		unset( $this->sync_queue[ $object_id ] );
+
+		/**
+		 * Fires after item is removed from sync queue
+		 *
+		 * @hook ep_after_remove_from_queue
+		 * @param  {int} $object_id ID of object
+		 * @param  {array} $sync_queue Current sync queue
+		 * @since  3.5
+		 */
+		do_action( 'ep_after_remove_from_queue', $object_id, $this->sync_queue );
+
+		return true;
+	}
+
+	/**
 	 * Sync queued objects if the EP_SYNC_CHUNK_LIMIT is reached.
 	 *
 	 * @since 3.1.2

--- a/tests/php/includes/classes/TestSyncManager.php
+++ b/tests/php/includes/classes/TestSyncManager.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Test base SyncManager functionality
+ *
+ * @package elasticpress
+ */
+
+namespace ElasticPressTest;
+
+use ElasticPress;
+
+/**
+ * Test post indexable class
+ */
+class TestSyncManager extends BaseTestCase {
+	public function getTestRemoveFromQueueData() {
+		return array(
+			array(
+				// Starting queue
+				[ 1 => true, 2 => true, 3 => true, 4 => true, 5 => true ],
+
+				// Object to remove
+				4,
+
+				// Expected queue
+				[ 1 => true, 2 => true, 3 => true, 5 => true ],
+			),
+
+			// Invalid id
+			array(
+				// Starting queue
+				[ 1 => true, 2 => true, 3 => true, 4 => true, 5 => true ],
+
+				// Object to remove
+				'foo',
+
+				// Expected queue
+				[ 1 => true, 2 => true, 3 => true, 4 => true, 5 => true ],
+			),
+
+			// ID not present
+			array(
+				// Starting queue
+				[ 1 => true, 2 => true, 3 => true, 4 => true, 5 => true ],
+
+				// Object to remove
+				6,
+
+				// Expected queue
+				[ 1 => true, 2 => true, 3 => true, 4 => true, 5 => true ],
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider getTestRemoveFromQueueData
+	 */
+	public function testRemoveFromQueue( $queue, $object_id, $expected_queue ) {
+		$manager = $this->getMockBuilder( \ElasticPress\SyncManager::class )
+			->disableOriginalConstructor() // B/c we can't pass an arg to it and it expects one
+			->getMockForAbstractClass();
+
+		$manager->sync_queue = $queue;
+
+		$manager->remove_from_queue( $object_id );
+
+		$this->assertEquals( $expected_queue, $manager->sync_queue );
+	}
+}


### PR DESCRIPTION
EP has a bug where when a post is trashed, it will get immediately re-indexed b/c other changes during the same request end up adding it to the SyncManager queue, which re-indexes it during the shutdown or redirect hook.

The SyncManager doesn't attempt to determine if a given post _should_ be indexed before indexing it - if it's in the queue, it gets indexed (which is something we could improve).

So this PR adds a method for removing items from the queue and calls that method when posts are deleted or trashed, to ensure they aren't re-indexed.