### PR TITLE
Check post status before re-indexing after term changes

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -127,18 +127,18 @@ class SyncManager extends SyncManagerAbstract {
 
 			$post = get_post( $post_id );
 
+			$indexable_post_statuses = $indexable->get_indexable_post_status();
+
+			if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
+				return;
+			}
+
 			// Only re-index if the taxonomy is indexed for this post
 			$indexable_taxonomies = $indexable->get_indexable_post_taxonomies( $post );
 
 			$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
 
 			if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
-				return;
-			}
-
-			$indexable_post_statuses = $indexable->get_indexable_post_status();
-
-			if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 				return;
 			}
 
@@ -203,18 +203,18 @@ class SyncManager extends SyncManagerAbstract {
 
 		$post = get_post( $post_id );
 
+		$indexable_post_statuses = $indexable->get_indexable_post_status();
+
+		if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
+			return;
+		}
+
 		// Only re-index if the taxonomy is indexed for this post
 		$indexable_taxonomies = $indexable->get_indexable_post_taxonomies( $post );
 
 		$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
 
 		if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
-			return;
-		}
-
-		$indexable_post_statuses = $indexable->get_indexable_post_status();
-
-		if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -136,6 +136,12 @@ class SyncManager extends SyncManagerAbstract {
 				return;
 			}
 
+			$indexable_post_statuses = $indexable->get_indexable_post_status();
+
+			if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
+				return;
+			}
+
 			$indexable_post_types = $indexable->get_indexable_post_types();
 
 			if ( in_array( $post_type, $indexable_post_types, true ) ) {
@@ -203,6 +209,12 @@ class SyncManager extends SyncManagerAbstract {
 		$indexable_taxonomy_names = wp_list_pluck( $indexable_taxonomies, 'name' );
 
 		if ( ! in_array( $taxonomy, $indexable_taxonomy_names, true ) ) {
+			return;
+		}
+
+		$indexable_post_statuses = $indexable->get_indexable_post_status();
+
+		if ( ! in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
There is a bug in our term-change re-indexing code - it's not currently checking that the post status is indexable before re-indexing. This PR adds the checks for consistency with other indexing methods.

This all needs to be refactored into a reusable and consistent method for checking if a post is indexable, but that's a bigger project and this is a quick fix.