### PR TITLE
Allow bypassing the indexing in the SyncManager class

### DIFF
--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -148,6 +148,18 @@ abstract class SyncManager {
 		}
 
 		/**
+		 * Allow other code to intercept the sync process
+		 *
+		 * @hook pre_ep_index_sync_queue
+		 * @param  {\ElasticPress\SyncManager} $sync_manager SyncManager instance for the indexable
+		 * @param  {string} $indexable_slug Slug of the indexable being synced
+		 * @since  3.5
+		 */
+		if ( apply_filters( 'pre_ep_index_sync_queue', $this, $this->indexable_slug ) ) {
+			return;
+		}
+
+		/**
 		 * Backwards compat for pre-3.0
 		 */
 		foreach ( $this->sync_queue as $object_id => $value ) {

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -151,11 +151,12 @@ abstract class SyncManager {
 		 * Allow other code to intercept the sync process
 		 *
 		 * @hook pre_ep_index_sync_queue
-		 * @param  {\ElasticPress\SyncManager} $sync_manager SyncManager instance for the indexable
-		 * @param  {string} $indexable_slug Slug of the indexable being synced
-		 * @since  3.5
+		 * @param {boolean} $bail True to skip the rest of index_sync_queue(), false to continue normally
+		 * @param {\ElasticPress\SyncManager} $sync_manager SyncManager instance for the indexable
+		 * @param {string} $indexable_slug Slug of the indexable being synced
+		 * @since 3.5
 		 */
-		if ( apply_filters( 'pre_ep_index_sync_queue', $this, $this->indexable_slug ) ) {
+		if ( apply_filters( 'pre_ep_index_sync_queue', false, $this, $this->indexable_slug ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Adds a new filter to allow other code to intercept the default queue processing functionality.

This will allow us to send indexing operations to a different queue in some circumstances.