### PR TITLE
Added index update for wp_update_comment_count action

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -36,6 +36,7 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		add_action( 'wp_insert_post', array( $this, 'action_sync_on_update' ), 999, 3 );
+		add_action( 'wp_update_comment_count', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'add_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'edit_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'delete_post', array( $this, 'action_delete_post' ) );

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -136,6 +136,34 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test a post sync on comment count update
+	 *
+	 * @group post
+	 */
+	public function testPostSyncOnCommentCountUpdate() {
+		$post_id = Functions\create_and_sync_post();
+		
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$post_no_comments = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+
+		wp_insert_comment( 
+			array(
+				'comment_post_ID' => $post_id,
+				'comment_author' => 'Testy Testman',
+				'comment_content' => 'Test comment',
+			)
+		);
+
+		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->index_sync_queue();
+		
+		$post_with_comments = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
+
+		$this->assertEquals( 0, intval( $post_no_comments->comment_count ), 'comment count for post should be 0 initially' );
+		$this->assertEquals( 0, intval( $post_with_comments->comment_count ), 'comment count for post should be 1 after sync' );
+	}
+
+	/**
 	 * Test pagination with offset
 	 *
 	 * @since 2.1

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -159,8 +159,8 @@ class TestPost extends BaseTestCase {
 		
 		$post_with_comments = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 
-		$this->assertEquals( 0, intval( $post_no_comments->comment_count ), 'comment count for post should be 0 initially' );
-		$this->assertEquals( 0, intval( $post_with_comments->comment_count ), 'comment count for post should be 1 after sync' );
+		$this->assertEquals( 0, intval( $post_no_comments['comment_count'] ), 'comment count for post should be 0 initially' );
+		$this->assertEquals( 1, intval( $post_with_comments['comment_count'] ), 'comment count for post should be 1 after sync' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Added `wp_update_comment_count` action to SyncManager setup so the index stays consistent with the database.