### PR TITLE
Added index update for wp_update_comment_count action (#31)

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -36,6 +36,7 @@ class SyncManager extends SyncManagerAbstract {
 		}
 
 		add_action( 'wp_insert_post', array( $this, 'action_sync_on_update' ), 999, 3 );
+		add_action( 'wp_update_comment_count', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'add_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'edit_attachment', array( $this, 'action_sync_on_update' ), 999, 3 );
 		add_action( 'delete_post', array( $this, 'action_delete_post' ) );


### PR DESCRIPTION
* Added index update for wp_update_comment_count action

Added to keep index consistent with database.

* Added unit test for comment count update sync

* Fixed typo and switch from object to assoc notation