### PR TITLE
Index the components of the modified date and the gmt versions

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -299,7 +299,10 @@ class Post extends Indexable {
 			'permalink'             => get_permalink( $post_id ),
 			'terms'                 => $this->prepare_terms( $post ),
 			'meta'                  => $this->prepare_meta_types( $this->prepare_meta( $post ) ), // post_meta removed in 2.4.
-			'date_terms'            => $this->prepare_date_terms( $post_date ),
+			'date_terms'              => $this->prepare_date_terms( $post_date ),
+			'date_gmt_terms'          => $this->prepare_date_terms( $post_date_gmt ),
+			'modified_date_terms'     => $this->prepare_date_terms( $post_modified ),
+			'modified_date_gmt_terms' => $this->prepare_date_terms( $post_modified_gmt ),
 			'comment_count'         => $comment_count,
 			'comment_status'        => $comment_status,
 			'ping_status'           => $ping_status,

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -413,6 +413,120 @@ return array(
 					),
 				),
 			),
+			'date_gmt_terms' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'year'          => array( // 4 digit year (e.g. 2011).
+						'type' => 'integer',
+					),
+					'month'         => array( // Month number (from 1 to 12) alternate name 'monthnum'.
+						'type' => 'integer',
+					),
+					'm'             => array( // YearMonth (For e.g.: 201307).
+						'type' => 'integer',
+					),
+					'week'          => array( // Week of the year (from 0 to 53) alternate name 'w'.
+						'type' => 'integer',
+					),
+					'day'           => array( // Day of the month (from 1 to 31).
+						'type' => 'integer',
+					),
+					'dayofweek'     => array( // Accepts numbers 1-7 (1 is Sunday).
+						'type' => 'integer',
+					),
+					'dayofweek_iso' => array( // Accepts numbers 1-7 (1 is Monday).
+						'type' => 'integer',
+					),
+					'dayofyear'     => array( // Accepts numbers 1-366.
+						'type' => 'integer',
+					),
+					'hour'          => array( // Hour (from 0 to 23).
+						'type' => 'integer',
+					),
+					'minute'        => array( // Minute (from 0 to 59).
+						'type' => 'integer',
+					),
+					'second'        => array( // Second (0 to 59).
+						'type' => 'integer',
+					),
+				),
+			),
+			'modified_date_terms'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'year'          => array( // 4 digit year (e.g. 2011).
+						'type' => 'integer',
+					),
+					'month'         => array( // Month number (from 1 to 12) alternate name 'monthnum'.
+						'type' => 'integer',
+					),
+					'm'             => array( // YearMonth (For e.g.: 201307).
+						'type' => 'integer',
+					),
+					'week'          => array( // Week of the year (from 0 to 53) alternate name 'w'.
+						'type' => 'integer',
+					),
+					'day'           => array( // Day of the month (from 1 to 31).
+						'type' => 'integer',
+					),
+					'dayofweek'     => array( // Accepts numbers 1-7 (1 is Sunday).
+						'type' => 'integer',
+					),
+					'dayofweek_iso' => array( // Accepts numbers 1-7 (1 is Monday).
+						'type' => 'integer',
+					),
+					'dayofyear'     => array( // Accepts numbers 1-366.
+						'type' => 'integer',
+					),
+					'hour'          => array( // Hour (from 0 to 23).
+						'type' => 'integer',
+					),
+					'minute'        => array( // Minute (from 0 to 59).
+						'type' => 'integer',
+					),
+					'second'        => array( // Second (0 to 59).
+						'type' => 'integer',
+					),
+				),
+			),
+			'modified_date_gmt_terms' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'year'          => array( // 4 digit year (e.g. 2011).
+						'type' => 'integer',
+					),
+					'month'         => array( // Month number (from 1 to 12) alternate name 'monthnum'.
+						'type' => 'integer',
+					),
+					'm'             => array( // YearMonth (For e.g.: 201307).
+						'type' => 'integer',
+					),
+					'week'          => array( // Week of the year (from 0 to 53) alternate name 'w'.
+						'type' => 'integer',
+					),
+					'day'           => array( // Day of the month (from 1 to 31).
+						'type' => 'integer',
+					),
+					'dayofweek'     => array( // Accepts numbers 1-7 (1 is Sunday).
+						'type' => 'integer',
+					),
+					'dayofweek_iso' => array( // Accepts numbers 1-7 (1 is Monday).
+						'type' => 'integer',
+					),
+					'dayofyear'     => array( // Accepts numbers 1-366.
+						'type' => 'integer',
+					),
+					'hour'          => array( // Hour (from 0 to 23).
+						'type' => 'integer',
+					),
+					'minute'        => array( // Minute (from 0 to 59).
+						'type' => 'integer',
+					),
+					'second'        => array( // Second (0 to 59).
+						'type' => 'integer',
+					),
+				),
+			),
 		),
 	),
 );


### PR DESCRIPTION
Copies existing behavior for indexing `post_date`, but for `post_modified` and the gmt versions. Needed for full compatibility with WP_Date_Query()