### PR TITLE
Make the "pre object delete" hook apply to all indexables

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -183,6 +183,14 @@ abstract class Indexable {
 	 * @return boolean
 	 */
 	public function delete( $object_id, $blocking = true ) {
+		/**
+		 * Fires before object deletion
+		 *
+		 * @hook ep_delete_{indexable_slug}
+		 * @param  {int} $object_id ID of object being deleted
+		 */
+		do_action( 'ep_delete_' . $this->slug, $object_id );
+
 		return Elasticsearch::factory()->delete_document( $this->get_index_name(), $this->slug, $object_id, $blocking );
 	}
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -187,9 +187,10 @@ abstract class Indexable {
 		 * Fires before object deletion
 		 *
 		 * @hook ep_delete_{indexable_slug}
-		 * @param  {int} $object_id ID of object being deleted
+		 * @param {int} $object_id ID of object being deleted
+		 * @param {string} $indexable_slug The slug of the indexable type that is being deleted
 		 */
-		do_action( 'ep_delete_' . $this->slug, $object_id );
+		do_action( 'ep_delete_' . $this->slug, $object_id, $this->slug );
 
 		return Elasticsearch::factory()->delete_document( $this->get_index_name(), $this->slug, $object_id, $blocking );
 	}

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -352,14 +352,6 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		/**
-		 * Fires before post deletion
-		 *
-		 * @hook ep_delete_post
-		 * @param  {int} $post_id ID of post
-		 */
-		do_action( 'ep_delete_post', $post_id );
-
 		Indexables::factory()->get( 'post' )->delete( $post_id, false );
 
 		// Ensure that the post isn't queued for syncing (could have happened due to meta or other changes in same request)


### PR DESCRIPTION
Previously only the Post indexable's SyncManager fired this hook - this change moves the hook to `Indexable::delete()` so that it fires consistently for all indexable types.