### PR TITLE
New define to control the ES query log

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1321,15 +1321,25 @@ class Elasticsearch {
 	}
 
 	/**
-	 * Query logging. Don't log anything to the queries property when
-	 * WP_DEBUG is not enabled. Calls action 'ep_add_query_log' if you
-	 * want to access the query outside of the ElasticPress plugin. This
-	 * runs regardless of debufg settings.
+	 * Query logging.
+	 * If EP_QUERY_LOG is defined, use its value to control if
+	 * query logging is enabled. If not, only enable it if WP_DEBUG
+	 * or WP_EP_DEBUG are enabled.
+	 * Calls action 'ep_add_query_log' if you want to access the
+	 * query outside of the ElasticPress plugin. This runs regardless
+	 * of debug settings.
 	 *
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
-		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+		$log_enabled = false;
+		if ( defined( 'EP_QUERY_LOG' ) ) {
+			$log_enabled = EP_QUERY_LOG;
+		} elseif ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+			$log_enabled = true;
+		}
+
+		if ( $log_enabled ) {
 			$this->queries[] = $query;
 		}
 

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1322,9 +1322,11 @@ class Elasticsearch {
 
 	/**
 	 * Query logging.
+
 	 * If EP_QUERY_LOG is defined, use its value to control if
 	 * query logging is enabled. If not, only enable it if WP_DEBUG
 	 * or WP_EP_DEBUG are enabled.
+
 	 * Calls action 'ep_add_query_log' if you want to access the
 	 * query outside of the ElasticPress plugin. This runs regardless
 	 * of debug settings.

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1333,6 +1333,7 @@ class Elasticsearch {
 	 */
 	protected function add_query_log( $query ) {
 		$log_enabled = false;
+
 		if ( defined( 'EP_QUERY_LOG' ) ) {
 			$log_enabled = EP_QUERY_LOG;
 		} elseif ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {


### PR DESCRIPTION
# Description

Allow a better control on whether we want the Elasticsearch query log to be enabled or disabled, without depending on WP_DEBUG. There's a new define EP_QUERY_LOG that has precedence over WP_DEBUG if it's defined.

This will be used from mu-plugins search to disable query log for long execution commands, in order to keep memory usage under control.
