### PR TITLE
Address a few places where WP_CLI::error was used effectively stopping the CLI command execution, swap those out with WP_CLI::warning which do not stop script execution

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -617,7 +617,7 @@ class Command extends WP_CLI_Command {
 					if ( ! empty( $result['errors'] ) ) {
 						$this->delete_transient();
 
-						WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $site['blog_id'], $result['errors'] ) );
+						WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors on site %2$d: %3$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $site['blog_id'], $result['errors'] ) );
 					}
 				}
 
@@ -646,7 +646,7 @@ class Command extends WP_CLI_Command {
 				if ( ! empty( $result['errors'] ) ) {
 					$this->delete_transient();
 
-					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
+					WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
 			}
 
@@ -686,7 +686,7 @@ class Command extends WP_CLI_Command {
 				if ( ! empty( $result['errors'] ) ) {
 					$this->delete_transient();
 
-					WP_CLI::error( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
+					WP_CLI::warning( sprintf( esc_html__( 'Number of %1$s index errors: %2$d', 'elasticpress' ), esc_html( strtolower( $indexable->labels['singular'] ) ), $result['errors'] ) );
 				}
 			}
 		}
@@ -862,7 +862,7 @@ class Command extends WP_CLI_Command {
 										}
 									}
 
-									WP_CLI::error( implode( "\n", $response->get_error_messages() ) );
+									WP_CLI::warning( implode( "\n", $response->get_error_messages() ) );
 								}
 
 								if ( isset( $response['errors'] ) && true === $response['errors'] ) {


### PR DESCRIPTION
## Description

Indexing command outputs errors via `WP_CLI::error` which terminates the script execution. Judging by the code it seems like a bug and not the original intent. E.g. there's already an implementation of retries for a batch in `Command::index_helper()` but it doesn't work because the script bails on the first error encountered.

Effectively before this patch, any sort of an upstream error would terminate the script, which makes indexing process less resilient and reliable. 

