### PR TITLE
Indexing command: fix Cannot use object of type WP_Error as array for failed remote requests.

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -863,6 +863,7 @@ class Command extends WP_CLI_Command {
 									}
 
 									WP_CLI::warning( implode( "\n", $response->get_error_messages() ) );
+									continue;
 								}
 
 								if ( isset( $response['errors'] ) && true === $response['errors'] ) {


### PR DESCRIPTION
We have switched from using `WP_CLI::error()` to `WP_CLI::warning()` which doesn't terminate the execution. 

However, we forgot to account for the logic that processes "soft failures" which expects `$response` to be an array.

This PR fixes that by skipping to the next iteration if the `$response` is `WP_Error`.

