### PR TITLE
Indexable: Workaround for  potentially producing valid timestamps that would result in 5 digit years which DateTime::__construct can't handle

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -464,7 +464,14 @@ abstract class Indexable {
 			$datetime = '1971-01-01 00:00:01';
 			$time     = '00:00:01';
 
-			if ( false !== $timestamp ) {
+			/**
+			 * Workaround for `strtotime` potentially producing valid timestamps that would result in 5 digit years
+			 * which DateTime::__construct() can't handle,
+			 * resulting in an 'Uncaught Error: Call to a member function getTimestamp() on bool' in date_i18n.
+			 *
+			 * This better be fixed by 9999-12-31 23:59:59
+			 */
+			if ( false !== $timestamp && 253402300799 > $timestamp ) {
 				$date     = date_i18n( 'Y-m-d', $timestamp );
 				$datetime = date_i18n( 'Y-m-d H:i:s', $timestamp );
 				$time     = date_i18n( 'H:i:s', $timestamp );


### PR DESCRIPTION
During indexing of a site, it was discovered that on rare occasions a string can be parsed by `strtotime` would result in a timestamp, but that timestamp would refer to distant future (after 9999-12-31 23:59:59). 

`date_create  (DateTime::__construct())` that's used in `date_i18n` can't handle 5-digit years, thus resulting in the following error:

```
Uncaught Error: Call to a member function getTimestamp() on bool in ...
```

This PR addresses that by adding a simple check that verifies that produced timestamp refers to a point before Y10K.

Example bug:

`A420960 SUNNY` resulted in `256194140400` which lead to

```
date_create( "10088-06-19 23:00:00" )
// =>
bool(false)
```
