### PR TITLE
Fix deprecated field "include"

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1325,7 +1325,7 @@ class Post extends Indexable {
 			switch ( $args['fields'] ) {
 				case 'ids':
 					$formatted_args['_source'] = array(
-						'include' => array(
+						'includes' => array(
 							'post_id',
 						),
 					);
@@ -1333,7 +1333,7 @@ class Post extends Indexable {
 
 				case 'id=>parent':
 					$formatted_args['_source'] = array(
-						'include' => array(
+						'includes' => array(
 							'post_id',
 							'post_parent',
 						),

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -481,7 +481,7 @@ class Term extends Indexable {
 			switch ( $query_vars['fields'] ) {
 				case 'ids':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 						],
 					];
@@ -489,7 +489,7 @@ class Term extends Indexable {
 
 				case 'id=>name':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'name',
 						],
@@ -498,7 +498,7 @@ class Term extends Indexable {
 
 				case 'id=>parent':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'parent',
 						],
@@ -507,7 +507,7 @@ class Term extends Indexable {
 
 				case 'id=>slug':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_id',
 							'slug',
 						],
@@ -516,14 +516,14 @@ class Term extends Indexable {
 
 				case 'names':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'name',
 						],
 					];
 					break;
 				case 'tt_ids':
 					$formatted_args['_source'] = [
-						'include' => [
+						'includes' => [
 							'term_taxonomy_id',
 						],
 					];

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -215,7 +215,7 @@ class User extends Indexable {
 		 */
 		if ( isset( $query_vars['fields'] ) && 'all' !== $query_vars['fields'] && 'all_with_meta' !== $query_vars['fields'] ) {
 			$formatted_args['_source'] = [
-				'include' => (array) $query_vars['fields'],
+				'includes' => (array) $query_vars['fields'],
 			];
 		}
 


### PR DESCRIPTION
# Description

Our ElasticSearch cluster was complaining about some sites using a deprecated field `include`. It turned out to be the ElasticPress code, so this PR fixes it, setting the correct one `includes`