### PR TITLE
Performant pagination during bulk post indexing

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -905,7 +905,7 @@ class Command extends WP_CLI_Command {
 
 			$loop_counter++;
 			if ( ( $loop_counter % 10 ) === 0 ) {
-				$time_elapsed_diff = isset( $time_elapsed ) ? ' (+' . (string) ( timer_stop( 0, 2 ) - $time_elapsed ). ')' : '';
+				$time_elapsed_diff = isset( $time_elapsed ) ? ' (+' . (string) ( timer_stop( 0, 2 ) - $time_elapsed ) . ')' : '';
 				$time_elapsed      = timer_stop( 0, 2 );
 				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . $time_elapsed . $time_elapsed_diff ) );
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -500,7 +500,7 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Index all posts for a site or network wide
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--start-post-id] [--end-post-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix]
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--start-object-id] [--end-object-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix]
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -750,13 +750,12 @@ class Command extends WP_CLI_Command {
 			$query_args['offset'] = absint( $args['offset'] );
 		}
 
-		// More performant pagination. Keeping behind this feature flag for now during testing.
-		if ( ! empty( $args['advanced-pagination'] ) ) {
-			$query_args['ep_indexing_advanced_pagination'] = true;
+		if ( ! empty( $args['start-object-id'] ) && is_numeric( $args['start-object-id'] ) ) {
+			$query_args['ep_indexing_start_object_id'] = $args['start-object-id'];
+		}
 
-			if ( ! empty( $args['start-object-id'] ) && is_numeric( $args['start-object-id'] ) ) {
-				$query_args['ep_indexing_start_object_id'] = $args['start-object-id'];
-			}
+		if ( ! empty( $args['last-object-id'] ) && is_numeric( $args['last-object-id'] ) ) {
+			$query_args['ep_indexing_last_object_id'] = $args['last-object-id'];
 		}
 
 		if ( ! empty( $args['post-ids'] ) ) {
@@ -785,8 +784,9 @@ class Command extends WP_CLI_Command {
 		}
 
 		$loop_counter = 0;
+		$total_objects_to_process = $indexable->query_db( $query_args )['total_objects'];
 		while ( true ) {
-			$query = $indexable->query_db( $query_args );
+			$query = $indexable->query_db( $query_args, 'exclude_total_objects_count' );
 
 			/**
 			 * Reset bulk object queue
@@ -904,7 +904,7 @@ class Command extends WP_CLI_Command {
 			}
 
 			$last_processed_object_id = $query['objects'][ array_key_last( $query['objects'] ) ]->ID;
-			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID Processed: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $query['total_objects'], (int) $last_processed_object_id ) );
+			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID Processed: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $total_objects_to_process, (int) $last_processed_object_id ) );
 
 			$loop_counter++;
 			if ( ( $loop_counter % 10 ) === 0 ) {

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -712,6 +712,7 @@ class Command extends WP_CLI_Command {
 		$index_queue         = [];
 		$killed_object_count = 0;
 		$failed_objects      = [];
+		$time_elapsed        = 0;
 
 		$no_bulk = false;
 
@@ -905,7 +906,7 @@ class Command extends WP_CLI_Command {
 
 			$loop_counter++;
 			if ( ( $loop_counter % 10 ) === 0 ) {
-				$time_elapsed_diff = isset( $time_elapsed ) ? ' (+' . (string) ( timer_stop( 0, 2 ) - $time_elapsed ) . ')' : '';
+				$time_elapsed_diff = $time_elapsed > 0 ? ' (+' . (string) ( timer_stop( 0, 2 ) - $time_elapsed ) . ')' : '';
 				$time_elapsed      = timer_stop( 0, 2 );
 				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . $time_elapsed . $time_elapsed_diff ) );
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -901,11 +901,17 @@ class Command extends WP_CLI_Command {
 			}
 
 			$last_processed_object_id = $query['objects'][ array_key_last( $query['objects'] ) ]->ID;
-			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID Processed: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $total_objects_to_process, (int) $last_processed_object_id ) );
+			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $total_objects_to_process, (int) $last_processed_object_id ) );
 
 			$loop_counter++;
 			if ( ( $loop_counter % 10 ) === 0 ) {
-				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . timer_stop() ) );
+				$time_elapsed_diff = isset( $time_elapsed ) ? ' (+' . (string) ( timer_stop( 0, 2 ) - $time_elapsed ). ')' : '';
+				$time_elapsed      = timer_stop( 0, 2 );
+				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . $time_elapsed . $time_elapsed_diff ) );
+
+				$current_memory = round( memory_get_usage() / 1024 / 1024, 2 ) . 'mb';
+				$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
+				WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 			}
 
 			$query_args['offset'] += $per_page;

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -500,7 +500,7 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Index all posts for a site or network wide
 	 *
-	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--advanced-pagination] [--start-post-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix]
+	 * @synopsis [--setup] [--network-wide] [--per-page] [--nobulk] [--show-errors] [--offset] [--start-post-id] [--end-post-id] [--indexables] [--show-bulk-errors] [--show-nobulk-errors] [--post-type] [--include] [--post-ids] [--ep-host] [--ep-prefix]
 	 *
 	 * @param array $args Positional CLI args.
 	 * @since 0.1.2
@@ -754,8 +754,8 @@ class Command extends WP_CLI_Command {
 			$query_args['ep_indexing_start_object_id'] = $args['start-object-id'];
 		}
 
-		if ( ! empty( $args['last-object-id'] ) && is_numeric( $args['last-object-id'] ) ) {
-			$query_args['ep_indexing_last_object_id'] = $args['last-object-id'];
+		if ( ! empty( $args['end-object-id'] ) && is_numeric( $args['end-object-id'] ) ) {
+			$query_args['ep_indexing_end_object_id'] = $args['end-object-id'];
 		}
 
 		if ( ! empty( $args['post-ids'] ) ) {
@@ -766,9 +766,6 @@ class Command extends WP_CLI_Command {
 			$include               = explode( ',', str_replace( ' ', '', $args['include'] ) );
 			$query_args['include'] = array_map( 'absint', $include );
 			$args['per-page']      = count( $query_args['include'] );
-
-			// Disable advanced pagination. Not useful if only indexing specific IDs.
-			$query_args['ep_indexing_advanced_pagination'] = false;
 		}
 
 		$per_page = $indexable->get_bulk_items_per_page();

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -781,9 +781,8 @@ class Command extends WP_CLI_Command {
 		}
 
 		$loop_counter = 0;
-		$total_objects_to_process = $indexable->query_db( $query_args )['total_objects'];
 		while ( true ) {
-			$query = $indexable->query_db( $query_args, 'exclude_total_objects_count' );
+			$query = $indexable->query_db( $query_args );
 
 			/**
 			 * Reset bulk object queue
@@ -902,7 +901,7 @@ class Command extends WP_CLI_Command {
 
 			$last_object_array_key    = array_keys( $query['objects'] )[ count( $query['objects'] ) - 1 ];
 			$last_processed_object_id = $query['objects'][ $last_object_array_key ]->ID;
-			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $total_objects_to_process, (int) $last_processed_object_id ) );
+			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $query['total_objects'], (int) $last_processed_object_id ) );
 
 			$loop_counter++;
 			if ( ( $loop_counter % 10 ) === 0 ) {

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -900,7 +900,8 @@ class Command extends WP_CLI_Command {
 				break;
 			}
 
-			$last_processed_object_id = $query['objects'][ array_key_last( $query['objects'] ) ]->ID;
+			$last_object_array_key    = array_keys( $query['objects'] )[ count( $query['objects'] ) - 1 ];
+			$last_processed_object_id = $query['objects'][ $last_object_array_key ]->ID;
 			WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $total_objects_to_process, (int) $last_processed_object_id ) );
 
 			$loop_counter++;

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -76,9 +76,6 @@ class Post extends Indexable {
 
 		if ( isset( $args['include'] ) ) {
 			$args['post__in'] = $args['include'];
-
-			// Disable advanced pagination. Not useful if only indexing specific IDs.
-			$args['ep_indexing_advanced_pagination'] = false;
 		}
 
 		/**
@@ -93,7 +90,12 @@ class Post extends Indexable {
 		 */
 		$args = apply_filters( 'ep_post_query_db_args', apply_filters( 'ep_index_posts_args', wp_parse_args( $args, $defaults ) ) );
 
-		// Force the following query args during advanced pagination to ensure things work correctly.
+		if ( isset( $args['include'] ) || isset( $args['post__in'] ) ) {
+			// Disable advanced pagination. Not useful if only indexing specific IDs.
+			$args['ep_indexing_advanced_pagination'] = false;
+		}
+
+		// Enforce the following query args during advanced pagination to ensure things work correctly.
 		if ( $args['ep_indexing_advanced_pagination'] ) {
 			$args = array_merge( $args, [
 				'suppress_filters' => false,

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -103,6 +103,7 @@ class Post extends Indexable {
 				'order'            => 'DESC',
 				'paged'            => 1,
 				'offset'           => 0,
+				'no_found_rows'    => true,
 			] );
 		}
 

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -71,7 +71,7 @@ class Post extends Indexable {
 			$args['posts_per_page'] = $args['per_page'];
 		}
 
-		// Default to using the advanced pagiation for better performance.
+		// Default to using the advanced pagination for better performance.
 		$args['ep_indexing_advanced_pagination'] = true;
 
 		if ( isset( $args['include'] ) ) {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -88,7 +88,7 @@ class Post extends Indexable {
 		 * @param  {array} $args Database arguments
 		 * @return  {array} New arguments
 		 */
-		$args = apply_filters( 'ep_post_query_db_args', apply_filters( 'ep_index_posts_args', wp_parse_args( $args, $defaults ) ) );
+		$args = apply_filters( 'ep_index_posts_args', apply_filters( 'ep_post_query_db_args', wp_parse_args( $args, $defaults ) ) );
 
 		if ( isset( $args['include'] ) || isset( $args['post__in'] ) ) {
 			// Disable advanced pagination. Not useful if only indexing specific IDs.

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -135,7 +135,7 @@ class Post extends Indexable {
 			// On the first loopthrough we begin with the requested start ID. Afterwards, use the last processed ID to paginate.
 			$start_range_post_id = $requested_start_id;
 			if ( is_numeric( $last_processed_id ) ) {
-				$start_range_post_id = number_format( $last_processed_id - '1', 0, '.', '' );
+				$start_range_post_id =  $last_processed_id - 1;
 			}
 
 			// Sanitize. Abort if unexpected data at this point.

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -64,14 +64,12 @@ class Post extends Indexable {
 			'orderby'             => 'ID',
 			'order'               => 'desc',
 			'no_found_rows'       => true,
+			'ep_indexing_advanced_pagination' => true,
 		];
 
 		if ( isset( $args['per_page'] ) ) {
 			$args['posts_per_page'] = $args['per_page'];
 		}
-
-		// Default to using the advanced pagination for better performance.
-		$args['ep_indexing_advanced_pagination'] = true;
 
 		if ( isset( $args['include'] ) ) {
 			$args['post__in'] = $args['include'];
@@ -84,8 +82,8 @@ class Post extends Indexable {
 		 *
 		 * @hook ep_post_query_db_args
 		 * @hook ep_index_posts_args
-		 * @param  {array} $args Database arguments
-		 * @return  {array} New arguments
+		 * @param {array} $args Database arguments
+		 * @return {array} New arguments
 		 */
 		$args = apply_filters( 'ep_index_posts_args', apply_filters( 'ep_post_query_db_args', wp_parse_args( $args, $defaults ) ) );
 

--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -546,6 +546,9 @@ function action_wp_ajax_ep_index() {
 		]
 	);
 
+	// Disable during dashboard indexing for now. Support would be possible if desired in the future.
+	$args['ep_indexing_advanced_pagination'] = false;
+
 	$query = $indexable->query_db( $args );
 
 	$index_meta['found_items'] = (int) $query['total_objects'];

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -142,12 +142,12 @@ class TestPost extends BaseTestCase {
 	 */
 	public function testPostSyncOnCommentCountUpdate() {
 		$post_id = Functions\create_and_sync_post();
-		
+
 		ElasticPress\Elasticsearch::factory()->refresh_indices();
 
 		$post_no_comments = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 
-		wp_insert_comment( 
+		wp_insert_comment(
 			array(
 				'comment_post_ID' => $post_id,
 				'comment_author' => 'Testy Testman',
@@ -156,7 +156,7 @@ class TestPost extends BaseTestCase {
 		);
 
 		ElasticPress\Indexables::factory()->get( 'post' )->sync_manager->index_sync_queue();
-		
+
 		$post_with_comments = ElasticPress\Indexables::factory()->get( 'post' )->get( $post_id );
 
 		$this->assertEquals( 0, intval( $post_no_comments['comment_count'] ), 'comment count for post should be 0 initially' );
@@ -4954,44 +4954,95 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
-	 * Tests the constructor for the Indexable\Post class.
+	 * Tests the query_db method.
 	 *
 	 * @return void
 	 * @group post
 	 */
 	public function testQueryDb() {
+		$indexable_post_object = new \ElasticPress\Indexable\Post\Post();
 
-		$exclude_post_id = Functions\create_and_sync_post();
-		$post_id = Functions\create_and_sync_post();
+		$post_id_1 = Functions\create_and_sync_post();
+		$post_id_2 = Functions\create_and_sync_post();
+		$post_id_3 = Functions\create_and_sync_post();
 
-		$post = new \ElasticPress\Indexable\Post\Post();
-
-		$results = $post->query_db(
+		// Test the first loop of the indexing.
+		$results = $indexable_post_object->query_db(
 			[
 				'per_page' => 1,
-				'include'  => [ $post_id ],
 			]
 		);
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $post_id_3, $post_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
 
-		$this->assertCount( 1, $post_ids );
-		$this->assertContains( $post_id, $post_ids );
-		$this->assertSame( 1, absint( $results['total_objects'] ) );
-
-		$results = $post->query_db(
+		// Second loop.
+		$results = $indexable_post_object->query_db(
 			[
-				'exclude'  => [ $exclude_post_id ],
+				'per_page' => 1,
+				'ep_indexing_last_processed_object_id' => $post_id_3,
 			]
 		);
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $post_id_2, $post_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 3, $results['total_objects'] );
 
-		$this->assertNotContains( $exclude_post_id, $post_ids );
+		// A custom start_object_id was passed in.
+		$results = $indexable_post_object->query_db(
+			[
+				'per_page' => 1,
+				'ep_indexing_start_object_id' => $post_id_1,
+			]
+		);
 
-		// Set up a few posts for the filters.
+		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $post_id_1, $post_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 1, $results['total_objects'] );
+
+		// Passing custom start and last post IDs. Second loop.
+		$results = $indexable_post_object->query_db(
+			[
+				'per_page' => 1,
+				'ep_indexing_start_object_id' => $post_id_3,
+				'ep_indexing_end_object_id' => $post_id_2,
+				'ep_indexing_last_processed_object_id' => $post_id_3,
+			]
+		);
+
+		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $post_id_2, $post_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 2, $results['total_objects'] );
+
+		// Specific post IDs
+		$results = $indexable_post_object->query_db(
+			[
+				'per_page' => 1,
+				'include'  => [ $post_id_1 ],
+			]
+		);
+
+		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
+		$this->assertEquals( $post_id_1, $post_ids[0] );
+		$this->assertCount( 1, $results['objects'] );
+		$this->assertEquals( 1, $results['total_objects'] );
+	}
+
+	/**
+	 * Test the filters in query_db.
+	 *
+	 * @return void
+	 * @group post
+	 */
+	function testQueryDbFilters() {
+		$indexable_post_object = new \ElasticPress\Indexable\Post\Post();
+
 		$args_post_ids = [];
-
 		$args_post_ids[] = Functions\create_and_sync_post();
 		$args_post_ids[] = Functions\create_and_sync_post();
 		$args_post_ids[] = Functions\create_and_sync_post();
@@ -5011,13 +5062,12 @@ class TestPost extends BaseTestCase {
 		add_filter( 'ep_post_query_db_args', $defaults_filter );
 		add_filter( 'ep_index_posts_args', $index_filter );
 
-		$results = $post->query_db( [] );
+		$results = $indexable_post_object->query_db( [] );
 
 		remove_filter( 'ep_post_query_db_args', $defaults_filter );
 		remove_filter( 'ep_index_posts_args', $index_filter );
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
-
 		$this->assertCount( 3, $post_ids );
 		$this->assertContains( $args_post_ids[2], $post_ids );
 		$this->assertNotContains( $args_post_ids[3], $post_ids );


### PR DESCRIPTION
# Purpose

Pagination with SQL's offset can get considerably slow on large sites as it has to tread through all the rows until it finds where to pick up. This PR switches away from using offset and instead ranges of post IDs which allows it to execute queries much faster. I've also prevented the need for running `SQL_CALC_FOUND_ROWS` on each query. There are comparisons of the query changes and performance profiling at the end.

To accomplish this new way of pagination while still using WP_Query, I'm passing custom query args and then filtering on `posts_where` based on these args.

# Testing

At the moment, I've kept the functionality behind a feature flag to make testing/comparing easier. To test, you'll want to apply this PR but then also add the `[--advanced-pagination] [--start-post-id]` CLI args to the docblock in `search/includes/classes/commands/class-corecommand.php` to allow them to passthrough the `wp vip-search index` CLI if you want to use that.

Ideally this just happens by default when it's possible, and we remove the feature flag & related logic when it's merged.

```
wp vip-search index --version=2 --indexables=post --advanced-pagination --start-post-id=2500000
```

I'm not 100% sure on the "end range" functionality you'll see in the code, and would appreciate some advice there. Mainly, is it worth it? Removing the end range appears to actually (very slightly) speed up the query and makes the code a bit simpler, but having the end-range does highly limit the rows scanned. Could go even further on limiting rows scanned, as right now there is an arbitrary limit of 50,000 IDs. In testing, changing this to lower doesn't really have an effect - it's already very fast.

# Profiling

```
### CURRENT STATUS

explain SELECT SQL_CALC_FOUND_ROWS  wp_posts.* FROM wp_posts  WHERE 1=1  AND wp_posts.post_type IN (XXX) AND ((wp_posts.post_status = 'publish' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'trash' OR wp_posts.post_status = 'inherit' OR wp_posts.post_status = 'request-pending' OR wp_posts.post_status = 'request-confirmed' OR wp_posts.post_status = 'request-failed' OR wp_posts.post_status = 'request-completed' OR wp_posts.post_status = 'spam' OR wp_posts.post_status = 'pitch' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'needs-editing' OR wp_posts.post_status = 'ready-to-publish' OR wp_posts.post_status = 'sync-only' OR wp_posts.post_status = 'private'))  ORDER BY wp_posts.ID DESC LIMIT 1500000, 500;

+------+-------------+----------+-------+------------------+---------+---------+------+---------+-------------+
| id   | select_type | table    | type  | possible_keys    | key     | key_len | ref  | rows    | Extra       |
+------+-------------+----------+-------+------------------+---------+---------+------+---------+-------------+
|    1 | SIMPLE      | wp_posts | index | type_status_date | PRIMARY | 8       | NULL | 5714850 | Using where |
+------+-------------+----------+-------+------------------+---------+---------+------+---------+-------------+

In the following tests, I had to drop to 250 posts per page instead of 500 (timeouts otherwise) and I removed SQL_CALC_FOUND_ROWS for a more fair comparison due to how I changed the logic in this PR.
Otherwise, you could expect 60+ second queries that often timeout. You'll see how offset gets progressively worse even with these adjustments:

Offset 2500: 0.35 secs
Offset 25000: 1.54 secs
Offset 250000: 23.42 secs
Offset 2500000: 35.66 sec

### WITH THIS PR

explain SELECT wp_posts.* FROM wp_posts  WHERE 1=1 AND wp_posts.ID < 2598793 AND wp_posts.ID > 2548793  AND wp_posts.post_type IN (XXX) AND ((wp_posts.post_status = 'publish' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'trash' OR wp_posts.post_status = 'inherit' OR wp_posts.post_status = 'request-pending' OR wp_posts.post_status = 'request-confirmed' OR wp_posts.post_status = 'request-failed' OR wp_posts.post_status = 'request-completed' OR wp_posts.post_status = 'spam' OR wp_posts.post_status = 'pitch' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'needs-editing' OR wp_posts.post_status = 'ready-to-publish' OR wp_posts.post_status = 'sync-only' OR wp_posts.post_status = 'private'))  ORDER BY wp_posts.ID DESC LIMIT 0, 500;

+------+-------------+----------+-------+--------------------------+---------+---------+------+-------+-------------+
| id   | select_type | table    | type  | possible_keys            | key     | key_len | ref  | rows  | Extra       |
+------+-------------+----------+-------+--------------------------+---------+---------+------+-------+-------------+
|    1 | SIMPLE      | wp_posts | range | PRIMARY,type_status_date | PRIMARY | 8       | NULL | 81838 | Using where |
+------+-------------+----------+-------+--------------------------+---------+---------+------+-------+-------------+

 Actual Query Time: 0.28 sec. No noticeable fluctuation with differing IDs.

Perhaps worth noting that query time is 0.27 sec if I remove the end range (wp_posts.ID > 2548793), though then 2857433 rows are scanned.
```
