### PR TITLE
Update/hide ep menus

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -27,11 +27,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since  2.1
  */
 function setup() {
-	if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) { // Must be network admin in multisite.
-		add_action( 'network_admin_menu', __NAMESPACE__ . '\action_admin_menu' );
-		add_action( 'admin_bar_menu', __NAMESPACE__ . '\action_network_admin_bar_menu', 50 );
-	} else {
-		add_action( 'admin_menu', __NAMESPACE__ . '\action_admin_menu' );
+	if ( defined( 'VIP_EP_SHOW_MENU_LINKS' ) && VIP_EP_SHOW_MENU_LINKS ) {
+		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) { // Must be network admin in multisite.
+			add_action( 'network_admin_menu', __NAMESPACE__ . '\action_admin_menu' );
+			add_action( 'admin_bar_menu', __NAMESPACE__ . '\action_network_admin_bar_menu', 50 );
+		} else {
+			add_action( 'admin_menu', __NAMESPACE__ . '\action_admin_menu' );
+		}
 	}
 
 	add_action( 'wp_ajax_ep_save_feature', __NAMESPACE__ . '\action_wp_ajax_ep_save_feature' );


### PR DESCRIPTION

### Description of the Change

The aim is to hide the ElastiPress Menus :
![image](https://user-images.githubusercontent.com/19240162/94821108-8521df00-0401-11eb-91de-ec3a353f886b.png)


### Alternate Designs

I was thinking about instead of never adding those actions, remove them outside of this plugin, but I am not sure if that would work?

### Benefits

Menus will be hidden

### Possible Drawbacks

N/A

### Verification Process

* Run your local environment or sandbox with master code
* Make sure it is a multisite
* Set following in your config:
```
define( 'VIP_ENABLE_VIP_SEARCH', true );
define( 'EP_IS_NETWORK', true );
```
* See that the menu links are there
* Update submodule of mu-plugins to this branch
* See that the menus from the screenshot are gone.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [/] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [/] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [/] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry
N/A
