### PR TITLE
Refactor the post term preparation during bulk indexing

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -385,7 +385,7 @@ class Post extends Indexable {
 		 * @param  {WP_Post} Post object
 		 * @return  {array} New taxonomies
 		 */
-		$selected_taxonomies = apply_filters( 'ep_sync_taxonomies', $selected_taxonomies, $post );
+		$selected_taxonomies = (array) apply_filters( 'ep_sync_taxonomies', $selected_taxonomies, $post );
 
 		// Important we validate here to ensure there are no imposters, as just one would cause wp_get_object_terms() to fail.
 		$validated_taxonomies = [];

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -457,7 +457,7 @@ class Post extends Indexable {
 
 		// Re-index with the taxonomy as the array key, and all the terms underneath.
 		$prepared_terms = [];
-		foreach( $terms_dictionary as $term_to_prepare ) {
+		foreach ( $terms_dictionary as $term_to_prepare ) {
 			$taxonomy_index = $term_to_prepare['taxonomy'];
 
 			if ( ! isset( $prepared_terms[ $taxonomy_index ] ) ) {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5058,11 +5058,11 @@ class TestPost extends BaseTestCase {
 
 		wp_set_post_terms( $post_id, 'testPrepareDocumentFallbacks', 'category', true );
 
-		add_filter( 'ep_sync_taxonomies', '__return_false' );
+		add_filter( 'ep_sync_taxonomies', '__return_empty_array' );
 
 		$post_args = $post->prepare_document( $post_id );
 
-		remove_filter( 'ep_sync_taxonomies', '__return_false' );
+		remove_filter( 'ep_sync_taxonomies', '__return_empty_array' );
 
 		$this->assertTrue( is_array( $post_args ) );
 		$this->assertTrue( is_array( $post_args['terms'] ) );

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -399,8 +399,9 @@ class TestPost extends BaseTestCase {
 		$taxonomy_name = rand_str( 32 );
 		register_taxonomy( $taxonomy_name, $test_post->post_type, array( 'label' => $taxonomy_name ) );
 		register_taxonomy_for_object_type( $taxonomy_name, $test_post->post_type );
-		$parent_term = wp_insert_term( rand_str( 32 ), $taxonomy_name );
-		$test_term   = wp_insert_term( rand_str( 32 ), $taxonomy_name, [ 'parent' => $parent_term['term_id'] ] );
+		$parent_term_parent  = wp_insert_term( rand_str( 32 ), $taxonomy_name );
+		$parent_term         = wp_insert_term( rand_str( 32 ), $taxonomy_name, [ 'parent' => $parent_term_parent['term_id'] ] );
+		$test_term           = wp_insert_term( rand_str( 32 ), $taxonomy_name, [ 'parent' => $parent_term['term_id'] ] );
 
 		// Assign the test term to our post and sync it up.
 		wp_set_object_terms( $test_post_id, array( $test_term['term_id'] ), $taxonomy_name, true );
@@ -411,10 +412,10 @@ class TestPost extends BaseTestCase {
 
 		// Now ensure all the appropiate term data is present.
 		$indexed_term_data  = $indexed_post_data['terms'][ $taxonomy_name ];
-		$this->assertTrue( count( $indexed_term_data ) === 2 );
+		$this->assertTrue( count( $indexed_term_data ) === 3 );
 
 		foreach ( $indexed_term_data as $indexed_term ) {
-			$this->assertTrue( in_array( $indexed_term['term_id'], [ $test_term['term_id'], $parent_term['term_id'] ], true ) );
+			$this->assertTrue( in_array( $indexed_term['term_id'], [ $test_term['term_id'], $parent_term['term_id'], $parent_term_parent['term_id'] ], true ) );
 
 			$actual_data      = get_term( $indexed_term['term_id'], $taxonomy_name, ARRAY_A );
 			$term_order_query = $wpdb->get_results( $wpdb->prepare( "SELECT term_order FROM $wpdb->term_relationships WHERE object_id = %d AND term_taxonomy_id = %d;", $test_post_id, $indexed_term[ 'term_taxonomy_id' ] ), OBJECT );


### PR DESCRIPTION
Part 3 of speeding up the bulk indexing (and content validation!).

## Problem

In an indexing request spanning 97.819 seconds (xdebug profiling enabled - two rounds of 250 posts), 57.950 of that is spent in `prepare_terms()` on a large-ish production site with some extra taxonomies. 9,884 calls are made to get_the_terms() due to the way the current term preparation is setup to run a new query for each different taxonomy being indexed, per post.

![gn-before-fixes](https://user-images.githubusercontent.com/8536129/95365206-758a1680-0897-11eb-8d6b-bee72d305537.png)

## Solution

Make it faster 🙂

- I've refactored `prepare_terms()` so that we can request all the terms for all indexable taxonomies at once via `wp_get_object_terms()`.
  - Unlike with get_the_terms(), we can prevent some unnecessary populating of the object cache while indexing.
  - Can also now prevent `update_termmeta_cache()` from running on each term, as we do not need term meta at all.
- Passing all the taxonomies at once to `wp_get_object_terms()` means we need to be sure that we don't pass in any invalid taxonomies, else the call will return nothing. So I updated `get_indexable_post_taxonomies()` as well to validate all the entries to ensure this does not happen.
- Additionally refactored/added `append_term_order()` as a more efficient way to fetch this extra data all at once, with a more specific and faster query. Also no longer need to fill up the object cache unnecessarily during this task.

The "main" query that fetches the full group of posts each loop can/should now include `update_post_term_cache => false` to further prevent unnecessary object cache additions during indexing. Can followup with this separately on the PR that addresses this query.

**Bonus**: Fixes a bug where `term_taxonomy_id` was not indexed on the pulled-in parent terms. (should `ep_sync_terms_allow_hierarchy` even be set to true by default on VIP?)

### Profiling

Remember that 57.950 out of 97.819 seconds that was spent on `prepare_terms()` earlier? With this patch, that turns into 10.082/51.286 seconds for the same type of request! For some realistic numbers, I disabled xdebug profiling and ran the same type of request again. Before the patch,  95.264 seconds for indexing two sets of 250 posts. After the patch, 25.223 seconds.

![gn-after-fixes](https://user-images.githubusercontent.com/8536129/95364114-065ff280-0896-11eb-96d5-8bc53937de3c.png)

(Note that the two other big "time takers" on the graph above are the date preparation and the main posts query. Both of which also have PRs for large improvements. All together, it will be speeeedy!)

## Testing

A little tricky right now, would be easier to test after the pagination PR is merged. But here is an example of what could be done:

```
1) Add some wp cli logging to output the last post id that is looped over in each round. And have the loop exit after two rounds.
2) Apply patch and run: wp vip-search index --version=2 --indexables=post --offset=25000 --per-page=250`
3) Revert patch, and inspect just a couple posts using a small range that includes post IDs between the two numbers you saw logged.
4) Example: wp vip-search health validate-contents --start_post_id=7292291 --last_post_id=7292300 --inspect
5) Does is validate? Awesome. If not, check that it's not the `term_taxonomy_id` bug showing itself.
```

Preferably we get the other two PRs merged in first. I can then follow up here with some further testing a bit easier.