### PR TITLE
Pass the Indexable instance to the ep_global_alias filter

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -148,9 +148,10 @@ abstract class Indexable {
 		 *
 		 * @hook ep_global_alias
 		 * @param  {string} $number Current alias
-		 * @return  {string} New alias
+		 * @param  {Indexable} $indexable Current indexable
+		 * @return {string} New alias
 		 */
-		return apply_filters( 'ep_global_alias', $alias );
+		return apply_filters( 'ep_global_alias', $alias, $this );
 	}
 
 	/**


### PR DESCRIPTION
This matches the behavior of the ep_index_name filter by passing in the Indexable, which can then be used to retrieve details like the `slug`.