### PR TITLE
Sanitizer user_login for drop-in user_nicename usage

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -298,7 +298,7 @@ class Post extends Indexable {
 		if ( $user instanceof WP_User ) {
 			$user_data = array(
 				'raw'          => $user->user_login,
-				'login'        => $user->user_login,
+				'login'        => sanitize_title( $user->user_login ),
 				'display_name' => $user->display_name,
 				'id'           => $user->ID,
 			);


### PR DESCRIPTION
In core, we generate the user_nicename value through `sanitize_title()`: https://github.com/WordPress/WordPress/blob/22c86907c4be29fad58d5724c36107426325f149/wp-includes/user.php#L1811

Since we don't have user_nicename synced over as a field, we'll need to use some sort of drop-in for author offloading usage: https://github.com/Automattic/es-wp-query/pull/10.

Note: Once this has merged, we'll need to re-index all active sites.