### PR TITLE
Prevent returning the wrong post counts from cache in multisite

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -174,7 +174,10 @@ class Post extends Indexable {
 			'ep_indexing_last_processed_object_id' => null,
 		] );
 
-		$cache_key = md5( json_encode( $normalized_query_args ) );
+		// To prevent returning cached responses for the wrong subsite when query args
+		// are the same, we append the blog ID.
+		$blog_id = get_current_blog_id();
+		$cache_key = md5( json_encode( $normalized_query_args ) ) . $blog_id;
 
 		if ( ! isset( $object_counts[ $cache_key ] ) ) {
 			$object_counts[ $cache_key ] = ( new WP_Query( $normalized_query_args ) )->found_posts;


### PR DESCRIPTION
# Description

Currently there's a bug with the VIP Search validate-counts command where the cache keys for post counts are the same for identical query args when iterating all subsites.

To account for this, we just need to append the cache key with the blog ID.