### PR TITLE
Add in wp_debug_backtrace_summary to query log

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1016,7 +1016,7 @@ class Elasticsearch {
 		
 		// Add in debugging information that can be used later, like in a Debug Bar panel.
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$query['backtrace']   = wp_debug_backtrace_summary();
+			$query['backtrace'] = wp_debug_backtrace_summary();
 		}
 
 		$this->add_query_log( $query );

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1013,6 +1013,12 @@ class Elasticsearch {
 
 		$query['time_finish'] = microtime( true );
 		$query['request']     = $request;
+		
+		// Add in debugging information that can be used later, like in a Debug Bar panel.
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$query['backtrace']   = wp_debug_backtrace_summary();
+		}
+
 		$this->add_query_log( $query );
 
 		/**

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1013,7 +1013,6 @@ class Elasticsearch {
 
 		$query['time_finish'] = microtime( true );
 		$query['request']     = $request;
-		
 		// Add in debugging information that can be used later, like in a Debug Bar panel.
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$query['backtrace'] = wp_debug_backtrace_summary();


### PR DESCRIPTION
If `WP_DEBUG` is on, this allows us to collect debugging information to be used later.  This can be useful in debugging what code is making ES requests, especially when there are multiple on a page.