### PR TITLE
Only load facet assets when widget is active

### DIFF
--- a/includes/classes/Feature/Facets/Facets.php
+++ b/includes/classes/Feature/Facets/Facets.php
@@ -160,6 +160,10 @@ class Facets extends Feature {
 	 * @since 2.5
 	 */
 	public function front_scripts() {
+		if ( ! is_active_widget( false, false, 'ep-facet' ) ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'elasticpress-facets',
 			EP_URL . 'dist/js/facets-script.min.js',


### PR DESCRIPTION
These assets are currently being loaded by default, regardless of whether the corresponding widget is active or not. The original repo that this is forked from has moved away from requiring jQuery and Underscore.js as dependencies for the facets script. While that would be a nice change to incorporate, a simpler step might be to only include the assets when they're needed.