### PR TITLE
Extract the building of index mapping + settings from put_mapping()

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -805,6 +805,13 @@ abstract class Indexable {
 	}
 
 	/**
+	 * Must implement a method that handles building mapping for ES
+	 *
+	 * @return array
+	 */
+	abstract public function build_mapping();
+
+	/**
 	 * Must implement a method that handles sending mapping to ES
 	 *
 	 * @return boolean

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -242,6 +242,18 @@ class Post extends Indexable {
 	 * @return array
 	 */
 	public function put_mapping() {
+		$mapping = $this->build_mapping();
+
+		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+	}
+
+	/**
+	 * Build mapping + settings for an index
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_mapping() {
 		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
 
 		if ( empty( $es_version ) ) {
@@ -285,7 +297,7 @@ class Post extends Indexable {
 		 */
 		$mapping = apply_filters( 'ep_post_mapping', $mapping );
 
-		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+		return $mapping;
 	}
 
 	/**

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -554,6 +554,18 @@ class Term extends Indexable {
 	 * @return boolean
 	 */
 	public function put_mapping() {
+		$mapping = $this->build_mapping();
+
+		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+	}
+
+	/**
+	 * Build mapping for terms
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_mapping() {
 		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
 
 		if ( empty( $es_version ) ) {
@@ -588,7 +600,7 @@ class Term extends Indexable {
 		 */
 		$mapping = apply_filters( 'ep_term_mapping', $mapping );
 
-		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+		return $mapping;
 	}
 
 	/**

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -751,7 +751,7 @@ class User extends Indexable {
 
 		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
 	}
-	
+
 	/**
 	 * Build mapping for users
 	 *

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -747,6 +747,18 @@ class User extends Indexable {
 	 * @return boolean
 	 */
 	public function put_mapping() {
+		$mapping = $this->build_mapping();
+
+		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+	}
+	
+	/**
+	 * Build mapping for users
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_mapping() {
 		$es_version = Elasticsearch::factory()->get_elasticsearch_version();
 		if ( empty( $es_version ) ) {
 			/**
@@ -787,7 +799,7 @@ class User extends Indexable {
 		 */
 		$mapping = apply_filters( 'ep_user_mapping', $mapping );
 
-		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
+		return $mapping;
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -75,7 +75,7 @@ class TestPost extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -65,6 +65,20 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group post
+	 */
+	public function testPostBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'post' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple post sync
 	 *
 	 * @since 0.9

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -110,7 +110,7 @@ class TestTerm extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -100,6 +100,20 @@ class TestTerm extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group term
+	 */
+	public function testTermBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'term' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple term sync
 	 *
 	 * @since 3.3

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -131,6 +131,20 @@ class TestUser extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group user
+	 */
+	public function testUserBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'user' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple user sync
 	 *
 	 * @since 3.0

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -141,7 +141,7 @@ class TestUser extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**


### PR DESCRIPTION
This makes it possible to build index mapping + settings independently from sending them to ES, which is required to automatically detect and resolve any discrepancies.