### PR TITLE
Add Indexable::build_settings()

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -812,6 +812,13 @@ abstract class Indexable {
 	abstract public function build_mapping();
 
 	/**
+	 * Must implement a method that handles building settings for ES
+	 *
+	 * @return array
+	 */
+	abstract public function build_settings();
+
+	/**
 	 * Must implement a method that handles sending mapping to ES
 	 *
 	 * @return boolean

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -301,6 +301,18 @@ class Post extends Indexable {
 	}
 
 	/**
+	 * Build settings for an index
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_settings() {
+		$mapping_and_settings = $this->build_mapping();
+
+		return $mapping_and_settings[ 'settings' ];
+	}
+
+	/**
 	 * Prepare a post for syncing
 	 *
 	 * @param int $post_id Post ID.

--- a/includes/classes/Indexable/Term/Term.php
+++ b/includes/classes/Indexable/Term/Term.php
@@ -604,6 +604,18 @@ class Term extends Indexable {
 	}
 
 	/**
+	 * Build settings for an index
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_settings() {
+		$mapping_and_settings = $this->build_mapping();
+
+		return $mapping_and_settings[ 'settings' ];
+	}
+
+	/**
 	 * Prepare a term document for indexing
 	 *
 	 * @param  int $term_id Term ID

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -803,6 +803,18 @@ class User extends Indexable {
 	}
 
 	/**
+	 * Build settings for an index
+	 *
+	 * @since  3.6
+	 * @return array
+	 */
+	public function build_settings() {
+		$mapping_and_settings = $this->build_mapping();
+
+		return $mapping_and_settings[ 'settings' ];
+	}
+
+	/**
 	 * Prepare a user document for indexing
 	 *
 	 * @param  int $user_id User id

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -751,7 +751,7 @@ class User extends Indexable {
 
 		return Elasticsearch::factory()->put_mapping( $this->get_index_name(), $mapping );
 	}
-	
+
 	/**
 	 * Build mapping for users
 	 *

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -75,7 +75,7 @@ class TestPost extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -65,6 +65,20 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group post
+	 */
+	public function testPostBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'post' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple post sync
 	 *
 	 * @since 0.9

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -79,6 +79,32 @@ class TestPost extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index settings
+	 * 
+	 * @since 3.6
+	 * @group post
+	 */
+	public function testPostBuildSettings() {
+		$settings = ElasticPress\Indexables::factory()->get( 'post' )->build_settings();
+
+		$expected_keys = array(
+			'index.number_of_shards',
+			'index.number_of_replicas',
+			'index.mapping.total_fields.limit',
+			'index.max_shingle_diff',
+			'index.max_result_window',
+			'index.mapping.ignore_malformed',
+			'analysis',
+		);
+
+		$actual_keys = array_keys( $settings );
+
+		$diff = array_diff( $expected_keys, $actual_keys );
+
+		$this->assertEquals( $diff, array() );
+	}
+
+	/**
 	 * Test a simple post sync
 	 *
 	 * @since 0.9

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -114,6 +114,29 @@ class TestTerm extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index settings
+	 * 
+	 * @since 3.6
+	 * @group post
+	 */
+	public function testTermBuildSettings() {
+		$settings = ElasticPress\Indexables::factory()->get( 'term' )->build_settings();
+
+		$expected_keys = array(
+			'index.mapping.total_fields.limit',
+			'index.max_result_window',
+			'index.max_shingle_diff',
+			'analysis',
+		);
+
+		$actual_keys = array_keys( $settings );
+
+		$diff = array_diff( $expected_keys, $actual_keys );
+
+		$this->assertEquals( $diff, array() );
+	}
+
+	/**
 	 * Test a simple term sync
 	 *
 	 * @since 3.3

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -110,7 +110,7 @@ class TestTerm extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -100,6 +100,20 @@ class TestTerm extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group term
+	 */
+	public function testTermBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'term' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple term sync
 	 *
 	 * @since 3.3

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -131,6 +131,20 @@ class TestUser extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index mappings
+	 * 
+	 * @since 3.6
+	 * @group user
+	 */
+	public function testUserBuildMapping() {
+		$mapping_and_settings = ElasticPress\Indexables::factory()->get( 'user' )->build_mapping();
+
+		// The mapping is currently expected to have both `mappings` and `settings` elements
+		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
+		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+	}
+
+	/**
 	 * Test a simple user sync
 	 *
 	 * @since 3.0

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -141,7 +141,7 @@ class TestUser extends BaseTestCase {
 
 		// The mapping is currently expected to have both `mappings` and `settings` elements
 		$this->assertArrayHasKey( 'settings', $mapping_and_settings, 'Built mapping is missing settings array' );
-		$this->assertArrayHasKey( 'mapping', $mapping_and_settings, 'Built mapping is missing mapping array' );
+		$this->assertArrayHasKey( 'mappings', $mapping_and_settings, 'Built mapping is missing mapping array' );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -145,6 +145,32 @@ class TestUser extends BaseTestCase {
 	}
 
 	/**
+	 * Test the building of index settings
+	 * 
+	 * @since 3.6
+	 * @group post
+	 */
+	public function testUserBuildSettings() {
+		$settings = ElasticPress\Indexables::factory()->get( 'user' )->build_settings();
+
+		$expected_keys = array(
+			'index.number_of_shards',
+			'index.number_of_replicas',
+			'index.mapping.total_fields.limit',
+			'index.max_shingle_diff',
+			'index.max_result_window',
+			'index.mapping.ignore_malformed',
+			'analysis',
+		);
+
+		$actual_keys = array_keys( $settings );
+
+		$diff = array_diff( $expected_keys, $actual_keys );
+
+		$this->assertEquals( $diff, array() );
+	}
+
+	/**
 	 * Test a simple user sync
 	 *
 	 * @since 3.0


### PR DESCRIPTION
Adds a new `Indexable::build_settings()` function to generate an index's settings independently of its mapping.

This is branched off of #78 so includes that code.