### PR TITLE
Add index settings retrieval and update on Indexable

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -769,12 +769,12 @@ class Elasticsearch {
 	/**
 	 * Get index settings.
 	 *
-	 * @param  string  $index Index name.
+	 * @param string $index Index name.
 	 *
-	 * @since  3.6
+	 * @since 3.6
 	 * @return array Raw ES response from the $index/_settings?flat_settings=true endpoint
 	 */
-	public function get_index_settings( $index) {
+	public function get_index_settings( $index ) {
 		$endpoint = trailingslashit( $index ) . '_settings?flat_settings=true';
 
 		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -763,6 +763,24 @@ class Elasticsearch {
 	}
 
 	/**
+	 * Get index settings.
+	 *
+	 * @param  string  $index       Index name.
+	 * @param  array   $query_args  Query parameters to pass through to the ES HTTP request
+	 *
+	 * @since  3.6
+	 * @return array Raw ES response from the $index/_settings endpoint
+	 */
+	public function get_index_settings( $index, $query_args = [] ) {
+		$endpoint = trailingslashit( $index ) . '_settings';
+		$request  = $this->remote_request( $endpoint, [], $query_args, 'get_index_settings' );
+
+		$settings = ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) );
+
+		return $settings;
+	}
+
+	/**
 	 * Delete an Elasticsearch index
 	 *
 	 * @param  string $index Index name.

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -765,15 +765,15 @@ class Elasticsearch {
 	/**
 	 * Get index settings.
 	 *
-	 * @param  string  $index       Index name.
-	 * @param  array   $query_args  Query parameters to pass through to the ES HTTP request
+	 * @param  string  $index Index name.
 	 *
 	 * @since  3.6
-	 * @return array Raw ES response from the $index/_settings endpoint
+	 * @return array Raw ES response from the $index/_settings?flat_settings=true endpoint
 	 */
-	public function get_index_settings( $index, $query_args = [] ) {
-		$endpoint = trailingslashit( $index ) . '_settings';
-		$request  = $this->remote_request( $endpoint, [], $query_args, 'get_index_settings' );
+	public function get_index_settings( $index) {
+		$endpoint = trailingslashit( $index ) . '_settings?flat_settings=true';
+
+		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );
 
 		$settings = ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) );
 

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -775,7 +775,13 @@ class Elasticsearch {
 
 		$request  = $this->remote_request( $endpoint, [], [], 'get_index_settings' );
 
-		$settings = ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) );
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		$response_body = wp_remote_retrieve_body( $request );
+
+		$settings = json_decode( $response_body, true );
 
 		return $settings;
 	}

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1457,15 +1457,28 @@ class Elasticsearch {
 	}
 
 	/**
-	 * Query logging. Don't log anything to the queries property when
-	 * WP_DEBUG is not enabled. Calls action 'ep_add_query_log' if you
-	 * want to access the query outside of the ElasticPress plugin. This
-	 * runs regardless of debufg settings.
+	 * Query logging.
+	 *
+	 * If EP_QUERY_LOG is defined, use its value to control if
+	 * query logging is enabled. If not, only enable it if WP_DEBUG
+	 * or WP_EP_DEBUG are enabled.
+	 *
+	 * Calls action 'ep_add_query_log' if you want to access the
+	 * query outside of the ElasticPress plugin. This runs regardless
+	 * of debug settings.
 	 *
 	 * @param array $query Query to log.
 	 */
 	protected function add_query_log( $query ) {
-		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+		$log_enabled = false;
+
+		if ( defined( 'EP_QUERY_LOG' ) ) {
+			$log_enabled = EP_QUERY_LOG;
+		} elseif ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+			$log_enabled = true;
+		}
+
+		if ( $log_enabled ) {
 			$this->queries[] = $query;
 		}
 

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -819,11 +819,25 @@ abstract class Indexable {
 	abstract public function build_settings();
 
 	/**
+	 * Must implement a method that handles retrieving index settings from ES
+	 *
+	 * @return boolean
+	 */
+	abstract public function get_index_settings();
+
+	/**
 	 * Must implement a method that handles sending mapping to ES
 	 *
 	 * @return boolean
 	 */
 	abstract public function put_mapping();
+
+	/**
+	 * Must implement a method that handles updating index settings for ES
+	 *
+	 * @return boolean
+	 */
+	abstract public function update_index_settings();
 
 	/**
 	 * Must implement a method that given an object ID, returns a formatted Elasticsearch

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -848,11 +848,20 @@ abstract class Indexable {
 	}
 
 	/**
-	 * Must implement a method that handles updating index settings for ES
+	 * Update index settings
 	 *
+	 * @param  array   $settings    Setting update array.
+	 * @param  boolean $close_first Optional. True if index must be closed prior to update.
+	 *                              Dynamic settings can be updated on open indices. Static
+	 *                              settings must be closed.  Default false.
+	 * @since  3.6
 	 * @return boolean
 	 */
-	abstract public function update_index_settings();
+	public function update_index_settings( $settings, $close_first = false ) {
+		$index_name = $this->get_index_name();
+
+		return Elasticsearch::update_index_settings( $index_name, $settings, $close_first );
+	}
 
 	/**
 	 * Must implement a method that given an object ID, returns a formatted Elasticsearch

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -840,11 +840,11 @@ abstract class Indexable {
 
 		// The ES response has the data nested under $index_name, so pull that out so we match the format of
 		// the settings from Indexable::build_settings() and the mapping file, for consistency
-		if ( ! isset( $result[ $index_name ] ) ) {
+		if ( ! isset( $result[ $index_name ][ 'settings' ] ) ) {
 			return new \WP_Error( 'index-settings-not-found', sprintf( 'Index settings for %s were not found in the Elasticsearch response', $index_name ) );
 		}
 
-		return $result[ $index_name ];
+		return $result[ $index_name ][ 'settings' ];
 	}
 
 	/**

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -842,11 +842,11 @@ abstract class Indexable {
 
 		// The ES response has the data nested under $index_name, so pull that out so we match the format of
 		// the settings from Indexable::build_settings() and the mapping file, for consistency
-		if ( ! isset( $result[ $index_name ][ 'settings' ] ) ) {
+		if ( ! isset( $result[ $index_name ]['settings'] ) ) {
 			return new \WP_Error( 'index-settings-not-found', sprintf( 'Index settings for %s were not found in the Elasticsearch response', $index_name ) );
 		}
 
-		return $result[ $index_name ][ 'settings' ];
+		return $result[ $index_name ]['settings'];
 	}
 
 	/**

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -862,7 +862,7 @@ abstract class Indexable {
 	public function update_index_settings( $settings, $close_first = false ) {
 		$index_name = $this->get_index_name();
 
-		return Elasticsearch::update_index_settings( $index_name, $settings, $close_first );
+		return Elasticsearch::factory()->update_index_settings( $index_name, $settings, $close_first );
 	}
 
 	/**

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -836,6 +836,10 @@ abstract class Indexable {
 
 		$result = Elasticsearch::factory()->get_index_settings( $index_name );
 
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
 		// The ES response has the data nested under $index_name, so pull that out so we match the format of
 		// the settings from Indexable::build_settings() and the mapping file, for consistency
 		if ( ! isset( $result[ $index_name ][ 'settings' ] ) ) {

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -812,6 +812,13 @@ abstract class Indexable {
 	abstract public function build_mapping();
 
 	/**
+	 * Must implement a method that handles sending mapping to ES
+	 *
+	 * @return boolean
+	 */
+	abstract public function put_mapping();
+
+	/**
 	 * Must implement a method that handles building settings for ES
 	 *
 	 * @return array
@@ -824,13 +831,6 @@ abstract class Indexable {
 	 * @return boolean
 	 */
 	abstract public function get_index_settings();
-
-	/**
-	 * Must implement a method that handles sending mapping to ES
-	 *
-	 * @return boolean
-	 */
-	abstract public function put_mapping();
 
 	/**
 	 * Must implement a method that handles updating index settings for ES

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -827,16 +827,14 @@ abstract class Indexable {
 
 	/**
 	 * Retrieve index settings from ES
-	 * 
-	 * @param array $query_args Optional array of query args to pass through to Elasticsearch's $index_name/_settings endpoint
 	 *
 	 * @since 3.6
 	 * @return array
 	 */
-	public function get_index_settings( $query_args = [] ) {
+	public function get_index_settings() {
 		$index_name = $this->get_index_name();
 
-		$result = Elasticsearch::factory()->get_index_settings( $index_name, $query_args );
+		$result = Elasticsearch::factory()->get_index_settings( $index_name );
 
 		// The ES response has the data nested under $index_name, so pull that out so we match the format of
 		// the settings from Indexable::build_settings() and the mapping file, for consistency


### PR DESCRIPTION
Adds helper functions for getting and updating an index's settings to the base `Indexable` class.

These are just light convenience wrappers around functions of the same name in `Elasticsearch.php`.

NOTE - our fork needs to bring in `Elasticsearch::update_index_settings()` from upstream before this will work. We can probably cherry-pick it.