### PR TITLE
Remove type from multiget

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -610,7 +610,7 @@ class Elasticsearch {
 	 * @return boolean|array
 	 */
 	public function get_documents( $index, $document_ids ) {
-		$path = $index . '/_doc/_mget';
+		$path = $index . '/_mget';
 
 		$request_args = [
 			'method' => 'POST',


### PR DESCRIPTION
## Description
ElasticPress has deprecated types. This is fine as in our use case we were not using it and everything was a `_doc` type.

However, in `mget` request we used to specify the type `_doc` in the request resulting in a warning in ES 7.X and an error in ES >= 8.

https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [n/a] This change has relevant unit tests (if applicable).
- [n/a] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
We only use multi-get in validate contents so:
So running `lando wp vip-search health validate-contents` before the change will throw a warning, and will work as expected without warning after the change.
