### PR TITLE
Add backtrace summary to logged queries

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1479,6 +1479,7 @@ class Elasticsearch {
 		}
 
 		if ( $log_enabled ) {
+			$query['backtrace'] = wp_debug_backtrace_summary( null, 1, false );
 			$this->queries[] = $query;
 		}
 


### PR DESCRIPTION
## Description

This PR adds a backtrace summary (generated via 'wp_debug_backstrace_summary') for each logged query. 

Ideally, we want more information (i.e. include also file name and file line where the call has happened). Unfortunately, `wp_debug_backstrace_summary` doesn't provide that level of information.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
