### PR TITLE
Avoid undefined notice on tests

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -878,6 +878,7 @@ class Elasticsearch {
 		];
 
 		$closed = false;
+
 		if ( $close_first ) {
 			$closed = $this->close_index( $index );
 		}

--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -877,6 +877,7 @@ class Elasticsearch {
 			'timeout' => 30,
 		];
 
+		$closed = false;
 		if ( $close_first ) {
 			$closed = $this->close_index( $index );
 		}


### PR DESCRIPTION
## Description
There is an error in our test run:

```
There was 1 error:

1) Automattic\VIP\Search\HealthJob_Test::test__vip_search_healthjob_check_health_with_inactive_features
Undefined variable: closed

/app/search/elasticpress/includes/classes/Elasticsearch.php:893
/app/search/elasticpress/includes/classes/Indexable.php:865
/app/search/includes/classes/class-health.php:828
/app/search/includes/classes/class-healthjob.php:282
/app/search/includes/classes/class-healthjob.php:193
/app/search/includes/classes/class-healthjob.php:178
/app/tests/search/includes/classes/test-class-healthjob.php:68

```

This fix defines the variable to avoid the error.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
TBA