### PR TITLE
Fix display filters by properly flattening the tree array

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -420,7 +420,7 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 	}
 
 	if ( $flat ) {
-		return flatten($terms_tree);
+		return flatten_tree_array( $terms_tree );
 	}
 
 	return $terms_tree;
@@ -432,12 +432,12 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 * @param  array       arr tree array
 * @return array.
 */
-function flatten($arr) {
+function flatten_tree_array( $arr ) {
     $result = [];
-    foreach($arr as $item) {
-        if (isset($item->children))
-            $result = array_merge($result, flatten($item->children));
-        unset($item->children);
+    foreach( $arr as $item ) {
+        if ( isset($item->children ) )
+            $result = array_merge( $result, flatten_tree_array( $item->children ) );
+        unset( $item->children );
         $result[] = $item;  
     }
     return $result;

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -435,8 +435,9 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 function flatten_tree_array( $arr ) {
     $result = [];
     foreach( $arr as $item ) {
-        if ( isset($item->children ) )
+        if ( isset($item->children ) ) {
             $result = array_merge( $result, flatten_tree_array( $item->children ) );
+		}
         unset( $item->children );
         $result[] = $item;  
     }

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -420,25 +420,27 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 	}
 
 	if ( $flat ) {
-		$flat_tree = [];
-
-		foreach ( $terms_tree as $term ) {
-			$flat_tree[] = $term;
-			$to_process  = $term->children;
-			while ( ! empty( $to_process ) ) {
-				$term        = array_shift( $to_process );
-				$flat_tree[] = $term;
-
-				if ( ! empty( $term->children ) ) {
-					$to_process = $term->children + $to_process;
-				}
-			}
-		}
-
-		return $flat_tree;
+		return flatten($terms_tree);
 	}
 
 	return $terms_tree;
+}
+
+/**
+* Flatten a tree based on children key.
+*
+* @param  array       arr tree array
+* @return array.
+*/
+function flatten($arr) {
+    $result = [];
+    foreach($arr as $item) {
+        if (isset($item->children))
+            $result = array_merge($result, flatten($item->children));
+        unset($item->children);
+        $result[] = $item;  
+    }
+    return $result;
 }
 
 /**


### PR DESCRIPTION
## Description
This PR fixes an issue with displaying the aggregated filters widget by properly flattening an array tree.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).


