### PR TITLE
Avoid calling Elasticsearch in case of deep pagination

### DIFF
--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -275,6 +275,16 @@ class QueryIntegration {
 				$index = implode( ',', $index );
 			}
 
+			// If result window is too big, we avoid doing a query that will fail
+			if ( array_key_exists('from', $formatted_args) && array_key_exists('size', $formatted_args)) {
+				$result_window     = $formatted_args['from'] + $formatted_args['size'];
+				$max_result_window = apply_filters( 'ep_max_result_window', 1000000 );
+				if ( $result_window > $max_result_window ) {
+					$query->elasticsearch_success = false;
+					return null;
+				}
+			}
+
 			$ep_query = Indexables::factory()->get( 'post' )->query_es( $formatted_args, $query->query_vars, $index, $query );
 
 			/**

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -276,7 +276,7 @@ class QueryIntegration {
 			}
 
 			// If result window is too big, we avoid doing a query that will fail
-			if ( array_key_exists('from', $formatted_args) && array_key_exists('size', $formatted_args)) {
+			if ( array_key_exists( 'from', $formatted_args ) && array_key_exists( 'size', $formatted_args ) ) {
 				$result_window     = $formatted_args['from'] + $formatted_args['size'];
 				$max_result_window = apply_filters( 'ep_max_result_window', 1000000 );
 				if ( $result_window > $max_result_window ) {

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -278,7 +278,7 @@ class QueryIntegration {
 			// If result window is too big, we avoid doing a query that will fail
 			if ( array_key_exists( 'from', $formatted_args ) && array_key_exists( 'size', $formatted_args ) ) {
 				$result_window     = $formatted_args['from'] + $formatted_args['size'];
-				$max_result_window = apply_filters( 'ep_max_result_window', 1000000 );
+				$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
 				if ( $result_window > $max_result_window ) {
 					$query->elasticsearch_success = false;
 					return null;


### PR DESCRIPTION
## Checklist

We have encountered multiple sites that are hit by bots requesting very deep pages. Those calls fail due to the max window size we have defined in Elasticsearch.

This PR introduces a check that detects deep paginated requests and kills them before hitting Elasticsearch, thus saving us from some extra load on the ES clusters.

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR on mu-plugins.
2. Set an artificially low max-window-size to ES.
3. See that request fails but no call to ES has been made.