### PR TITLE
Fix per page

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -774,6 +774,8 @@ class Command extends WP_CLI_Command {
 		if ( ! empty( $args['per-page'] ) ) {
 			$query_args['per_page'] = absint( $args['per-page'] );
 			$per_page               = $query_args['per_page'];
+		} else {
+			$query_args['per_page'] = $per_page;
 		}
 
 		if ( ! empty( $args['post-type'] ) ) {


### PR DESCRIPTION
## Description

Fix a bug when bulk indexing.

If per-page is not provided this can lead to missmatch between how much is queried for and 
how many records are skipped for the next batch.

Here we get $perPage, which ultimetly comes from a filter `ep_bulk_items_per_page`  https://github.com/Automattic/ElasticPress/blob/8e9c061e966aa3046f155a3375ae57a2d520d7e1/includes/classes/Command.php#L768

This filter we in the vip-search set to 500 (not default 350).

However the original code is not sending the per_page to the query_args. This means the default per-page will be used. Which is 350 for users indexable (ignoring this $per_page variable) - https://github.com/Automattic/ElasticPress/blob/develop/includes/classes/Indexable/User/User.php#L705


Finally, we will set offset to $per_page (even though it was not actually used to limit the number of records).


## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Have more than 350 users
1. Run `wp vip-search index --indexables=user`
1. Notice the batch is increasing by 350 not 500. but the offset is increasing by 500 leading to several users skipped.

e.g.
```
Processed 350/2723. Last Object ID: 140588410
Processed 700/2723. Last Object ID: 105722478
Processed 1050/2723. Last Object ID: 90888438
Processed 1400/2723. Last Object ID: 130799525
Processed 1750/2723. Last Object ID: 156824221
Processed 1973/2723. Last Object ID: 183164779
Number of users indexed: 1973  (not 2723)

```