### PR TITLE
Remove duplicate category_name, cat and tag_id from ES query when tax_query set

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -856,20 +856,22 @@ class Post extends Indexable {
 		 */
 
 		// Find root level taxonomies.
-		if ( isset( $args['category_name'] ) && ! empty( $args['category_name'] ) ) {
-			$args['tax_query'][] = array(
-				'taxonomy' => 'category',
-				'terms'    => array( $args['category_name'] ),
-				'field'    => 'slug',
-			);
-		}
+		if ( empty( $args['tax_query'] ) ) { // Remove duplicate queries from Core's backwards compat feature of setting 'category_name', 'cat' and 'tag_id': https://github.com/WordPress/WordPress/blob/5d99107bf3ab35aa3dda82c6b3903f5717771335/wp-includes/class-wp-query.php#L2193
+			if ( isset( $args['category_name'] ) && ! empty( $args['category_name'] ) ) {
+				$args['tax_query'][] = array(
+					'taxonomy' => 'category',
+					'terms'    => array( $args['category_name'] ),
+					'field'    => 'slug',
+				);
+			}
 
-		if ( isset( $args['cat'] ) && ! empty( $args['cat'] ) ) {
-			$args['tax_query'][] = array(
-				'taxonomy' => 'category',
-				'terms'    => array( $args['cat'] ),
-				'field'    => 'term_id',
-			);
+			if ( isset( $args['cat'] ) && ! empty( $args['cat'] ) ) {
+				$args['tax_query'][] = array(
+					'taxonomy' => 'category',
+					'terms'    => array( $args['cat'] ),
+					'field'    => 'term_id',
+				);
+			}
 		}
 
 		if ( isset( $args['tag'] ) && ! empty( $args['tag'] ) ) {
@@ -892,7 +894,7 @@ class Post extends Indexable {
 			$has_tag__and = true;
 		}
 
-		if ( isset( $args['tag_id'] ) && ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ) ) {
+		if ( isset( $args['tag_id'] ) && ! empty( $args['tag_id'] ) && ! is_array( $args['tag_id'] ) && empty( $args['tax_query'] ) ) {
 
 			// If you pass tag__in as a parameter, core adds the first
 			// term ID as tag_id, so we only need to append it if we have


### PR DESCRIPTION
## Description
Core has a funky backwards compat feature where category_name, cat and tag_id are set explicitly:

https://github.com/WordPress/WordPress/blob/5d99107bf3ab35aa3dda82c6b3903f5717771335/wp-includes/class-wp-query.php#L2193-L2215

However, this interferes with the ES query when tax_query is also set. For example, take this WP_Query to be offloaded:

```
	$args = array(
		'es' => true,
		'post_type' => 'post',
		'tax_query' => array(
			'relation' => 'OR',
			array(
				'taxonomy' => 'post_tag',
				'field'    => 'slug',
				'terms'    => array( 'toronto-traffic' ),
			),
			array(
				'relation' => 'AND',
					array(
						'taxonomy' => 'post_tag',
						'field'    => 'slug',
						'terms'    => array( 'toronto' ),
					),
					array(
						'taxonomy' => 'category',
						'field'    => 'slug',
						'terms'    => array( 'traffic' ),
					),
			),
		),
```

What we would expect from this is posts with a tag of `toronto-traffic` OR category of `traffic` and post_tag of `toronto`. The ES query would look like:

```
{
    "from": 0,
    "size": 10,
    "sort": [
        {
            "post_date": {
                "order": "desc"
            }
        }
    ],
    "query": {
        "match_all": {
            "boost": 1
        }
    },
    "post_filter": {
        "bool": {
            "must": [
                {
                    "bool": {
                        "should": [
                            {
                                "terms": {
                                    "terms.post_tag.slug": [
                                        "toronto-traffic"
                                    ]
                                }
                            },
                            {
                                "bool": {
                                    "must": [
                                        {
                                            "terms": {
                                                "terms.post_tag.slug": [
                                                    "toronto"
                                                ]
                                            }
                                        },
                                        {
                                            "terms": {
                                                "terms.category.slug": [
                                                    "traffic"
                                                ]
                                            }
                                        }
                                    ]
                                }
                            }
                        ]
                    }
                },
                {
                    "terms": {
                        "post_type.raw": [
                            "post"
                        ]
                    }
                },
                {
                    "terms": {
                        "post_status": [
                            "publish"
                        ]
                    }
                }
            ]
        }
    },
    "track_total_hits": true
}
```

However, ES currently returns the following query, where results that may only just have `traffic` as a category are returned:

```
{
    "from": 0,
    "size": 10,
    "sort": [
        {
            "post_date": {
                "order": "desc"
            }
        }
    ],
    "query": {
        "match_all": {
            "boost": 1
        }
    },
    "post_filter": {
        "bool": {
            "must": [
                {
                    "bool": {
                        "should": [
                            {
                                "terms": {
                                    "terms.post_tag.slug": [
                                        "toronto-traffic"
                                    ]
                                }
                            },
                            {
                                "bool": {
                                    "must": [
                                        {
                                            "terms": {
                                                "terms.post_tag.slug": [
                                                    "toronto"
                                                ]
                                            }
                                        },
                                        {
                                            "terms": {
                                                "terms.category.slug": [
                                                    "traffic"
                                                ]
                                            }
                                        }
                                    ]
                                }
                            },
                            {
                                "terms": {
                                    "terms.category.slug": [
                                        "traffic"
                                    ]
                                }
                            },
                            {
                                "terms": {
                                    "terms.category.term_id": [
                                        12345 // traffic category term_id
                                    ]
                                }
                            },
                            {
                                "terms": {
                                    "terms.post_tag.term_id": [
                                        6789 // toronto-traffic post_tag 
                                    ]
                                }
                            }
                        ]
                    }
                },
                {
                    "terms": {
                        "post_type.raw": [
                            "post"
                        ]
                    }
                },
                {
                    "terms": {
                        "post_status": [
                            "publish"
                        ]
                    }
                }
            ]
        }
    },
    "track_total_hits": true
}
```

It ends up treating the three conditions separately as an OR.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1) Create post A and only assign it to category `traffic`.
2) Create post B and assign it to category `traffic` and post_tag `toronto`.
3) Create post C and assign it to post_tag `toronto-traffic`.
4) Offload the WP_Query described in description.
5) You will see that post A will be returned in the results (when it shouldn't be).
6) Apply patch.
7) You will not see post A returned in the results anymore.