### PR TITLE
Moving window size check

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -358,6 +358,15 @@ abstract class Indexable {
 	 * @return array
 	 */
 	public function query_es( $formatted_args, $query_args, $index = null, $query_object = null ) {
+		// If result window is too big, we avoid doing a query that will fail
+		if ( array_key_exists( 'from', $formatted_args ) && array_key_exists( 'size', $formatted_args ) ) {
+			$result_window     = $formatted_args['from'] + $formatted_args['size'];
+			$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
+			if ( $result_window > $max_result_window ) {
+				return false;
+			}
+		}
+
 		if ( null === $index ) {
 			$index = $this->get_index_name();
 		}

--- a/includes/classes/Indexable/Post/QueryIntegration.php
+++ b/includes/classes/Indexable/Post/QueryIntegration.php
@@ -275,16 +275,6 @@ class QueryIntegration {
 				$index = implode( ',', $index );
 			}
 
-			// If result window is too big, we avoid doing a query that will fail
-			if ( array_key_exists( 'from', $formatted_args ) && array_key_exists( 'size', $formatted_args ) ) {
-				$result_window     = $formatted_args['from'] + $formatted_args['size'];
-				$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
-				if ( $result_window > $max_result_window ) {
-					$query->elasticsearch_success = false;
-					return null;
-				}
-			}
-
 			$ep_query = Indexables::factory()->get( 'post' )->query_es( $formatted_args, $query->query_vars, $index, $query );
 
 			/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -311,45 +311,45 @@ class TestUser extends BaseTestCase {
 		$this->assertEquals( 5, $user_query->total_users );
 	}
 
-	/**
-	 * Test user query number parameter
-	 *
-	 * @since 3.0
-	 * @group user
-	 */
-	public function testUserQueryNumber() {
-		$this->createAndIndexUsers();
-
-		$user_query = new \WP_User_Query(
-			[
-				'ep_integrate' => true,
-				'number'       => 1,
-			]
-		);
-
-		$this->assertEquals( 1, count( $user_query->results ) );
-		$this->assertEquals( 5, $user_query->total_users );
-
-		for ( $i = 1; $i <= 15; $i++ ) {
-			Functions\create_and_sync_user(
-				[
-					'user_login' => 'user' . $i . '-editor',
-					'role'       => 'administrator',
-				]
-			);
-		}
-
-		ElasticPress\Elasticsearch::factory()->refresh_indices();
-
-		$user_query = new \WP_User_Query(
-			[
-				'ep_integrate' => true,
-			]
-		);
-
-		$this->assertEquals( 18, count( $user_query->results ) );
-		$this->assertEquals( 18, $user_query->total_users );
-	}
+//	/**
+//	 * Test user query number parameter
+//	 *
+//	 * @since 3.0
+//	 * @group user
+//	 */
+//	public function testUserQueryNumber() {
+//		$this->createAndIndexUsers();
+//
+//		$user_query = new \WP_User_Query(
+//			[
+//				'ep_integrate' => true,
+//				'number'       => 1,
+//			]
+//		);
+//
+//		$this->assertEquals( 1, count( $user_query->results ) );
+//		$this->assertEquals( 5, $user_query->total_users );
+//
+//		for ( $i = 1; $i <= 15; $i++ ) {
+//			Functions\create_and_sync_user(
+//				[
+//					'user_login' => 'user' . $i . '-editor',
+//					'role'       => 'administrator',
+//				]
+//			);
+//		}
+//
+//		ElasticPress\Elasticsearch::factory()->refresh_indices();
+//
+//		$user_query = new \WP_User_Query(
+//			[
+//				'ep_integrate' => true,
+//			]
+//		);
+//
+//		$this->assertEquals( 18, count( $user_query->results ) );
+//		$this->assertEquals( 18, $user_query->total_users );
+//	}
 
 	/**
 	 * Test user query number parameter

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -348,7 +348,7 @@ class TestUser extends BaseTestCase {
 		);
 
 		$this->assertEquals( 18, count( $user_query->results ) );
-		$this->assertEquals( 18, $user_query->total_users );
+		$this->assertEquals( 19, $user_query->total_users );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -347,7 +347,7 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		$this->assertEquals( 18, count( $user_query->results ) );
+		$this->assertEquals( 19, count( $user_query->results ) );
 		// $this->assertEquals( 19, $user_query->total_users );
 	}
 

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -132,7 +132,7 @@ class TestUser extends BaseTestCase {
 
 	/**
 	 * Test the building of index mappings
-	 * 
+	 *
 	 * @since 3.6
 	 * @group user
 	 */
@@ -146,7 +146,7 @@ class TestUser extends BaseTestCase {
 
 	/**
 	 * Test the building of index settings
-	 * 
+	 *
 	 * @since 3.6
 	 * @group post
 	 */
@@ -347,8 +347,8 @@ class TestUser extends BaseTestCase {
 			]
 		);
 
-		$this->assertEquals( 19, count( $user_query->results ) );
-		$this->assertEquals( 19, $user_query->total_users );
+		$this->assertEquals( 18, count( $user_query->results ) );
+		$this->assertEquals( 18, $user_query->total_users );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -348,7 +348,7 @@ class TestUser extends BaseTestCase {
 		);
 
 		$this->assertEquals( 19, count( $user_query->results ) );
-		// $this->assertEquals( 19, $user_query->total_users );
+		$this->assertEquals( 18, $user_query->total_users );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -348,7 +348,7 @@ class TestUser extends BaseTestCase {
 		);
 
 		$this->assertEquals( 18, count( $user_query->results ) );
-		$this->assertEquals( 19, $user_query->total_users );
+		// $this->assertEquals( 19, $user_query->total_users );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -348,7 +348,7 @@ class TestUser extends BaseTestCase {
 		);
 
 		$this->assertEquals( 19, count( $user_query->results ) );
-		$this->assertEquals( 18, $user_query->total_users );
+		$this->assertEquals( 19, $user_query->total_users );
 	}
 
 	/**

--- a/tests/php/indexables/TestUser.php
+++ b/tests/php/indexables/TestUser.php
@@ -311,45 +311,45 @@ class TestUser extends BaseTestCase {
 		$this->assertEquals( 5, $user_query->total_users );
 	}
 
-//	/**
-//	 * Test user query number parameter
-//	 *
-//	 * @since 3.0
-//	 * @group user
-//	 */
-//	public function testUserQueryNumber() {
-//		$this->createAndIndexUsers();
-//
-//		$user_query = new \WP_User_Query(
-//			[
-//				'ep_integrate' => true,
-//				'number'       => 1,
-//			]
-//		);
-//
-//		$this->assertEquals( 1, count( $user_query->results ) );
-//		$this->assertEquals( 5, $user_query->total_users );
-//
-//		for ( $i = 1; $i <= 15; $i++ ) {
-//			Functions\create_and_sync_user(
-//				[
-//					'user_login' => 'user' . $i . '-editor',
-//					'role'       => 'administrator',
-//				]
-//			);
-//		}
-//
-//		ElasticPress\Elasticsearch::factory()->refresh_indices();
-//
-//		$user_query = new \WP_User_Query(
-//			[
-//				'ep_integrate' => true,
-//			]
-//		);
-//
-//		$this->assertEquals( 18, count( $user_query->results ) );
-//		$this->assertEquals( 18, $user_query->total_users );
-//	}
+	/**
+	 * Test user query number parameter
+	 *
+	 * @since 3.0
+	 * @group user
+	 */
+	public function testUserQueryNumber() {
+		$this->createAndIndexUsers();
+
+		$user_query = new \WP_User_Query(
+			[
+				'ep_integrate' => true,
+				'number'       => 1,
+			]
+		);
+
+		$this->assertEquals( 1, count( $user_query->results ) );
+		$this->assertEquals( 5, $user_query->total_users );
+
+		for ( $i = 1; $i <= 15; $i++ ) {
+			Functions\create_and_sync_user(
+				[
+					'user_login' => 'user' . $i . '-editor',
+					'role'       => 'administrator',
+				]
+			);
+		}
+
+		ElasticPress\Elasticsearch::factory()->refresh_indices();
+
+		$user_query = new \WP_User_Query(
+			[
+				'ep_integrate' => true,
+			]
+		);
+
+		$this->assertEquals( 18, count( $user_query->results ) );
+		$this->assertEquals( 18, $user_query->total_users );
+	}
 
 	/**
 	 * Test user query number parameter


### PR DESCRIPTION
## Description

The restriction we added in a previous PR (https://github.com/Automattic/ElasticPress/pull/89) only applied to a subset of cases, meaning that some sites in production would still do invalid requests.

By moving this check, we will be avoiding requests to ES when we know for sure that they will fail.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR on mu-plugins.
2. Set an artificially low max-window-size to ES.
3. See that request fails but no call to ES has been made.
