### PR TITLE
Adds support for custom vip_search_default_analyzer_filters

### DIFF
--- a/includes/mappings/post/5-0.php
+++ b/includes/mappings/post/5-0.php
@@ -48,7 +48,15 @@ return array(
 			'analyzer' => array(
 				'default'          => array(
 					'tokenizer' => 'standard',
-					'filter'    => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
+					/**
+					 * Filter Elasticsearch default analyzer's filters
+					 *
+					 * @since 3.6.2
+					 * @hook ep_default_analyzer_filters
+					 * @param  {array<string>} $filters Default filters
+					 * @return {array<string>} New filters
+					 */
+					'filter' => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *

--- a/includes/mappings/post/5-2.php
+++ b/includes/mappings/post/5-2.php
@@ -48,7 +48,15 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer'   => 'standard',
-					'filter'      => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
+					/**
+					 * Filter Elasticsearch default analyzer's filters
+					 *
+					 * @since 3.6.2
+					 * @hook ep_default_analyzer_filters
+					 * @param  {array<string>} $filters Default filters
+					 * @return {array<string>} New filters
+					 */
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
 					'char_filter' => array( 'html_strip' ),
 					/**
 					 * Filter Elasticsearch default language in mapping

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -64,7 +64,7 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer'   => 'standard',
-					'filter'      => array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
+					'filter'      => apply_filters( 'vip_search_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
 					'char_filter' => array( 'html_strip' ),
 					/**
 					 * Filter Elasticsearch default language in mapping

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -64,7 +64,14 @@ return array(
 			'analyzer'   => array(
 				'default'          => array(
 					'tokenizer'   => 'standard',
-					'filter'      => apply_filters( 'vip_search_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
+					/**
+					 * Filter Elasticsearch default analyzer's filters
+					 *
+					 * @hook ep_default_analyzer_filters
+					 * @param  {array<string>} $filters Default filters
+					 * @return {array<string>} New filters
+					 */
+					'filter'      => apply_filters( 'ep_default_analyzer_filters', array( 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
 					'char_filter' => array( 'html_strip' ),
 					/**
 					 * Filter Elasticsearch default language in mapping

--- a/includes/mappings/post/7-0.php
+++ b/includes/mappings/post/7-0.php
@@ -67,6 +67,7 @@ return array(
 					/**
 					 * Filter Elasticsearch default analyzer's filters
 					 *
+					 * @since 3.6.2
 					 * @hook ep_default_analyzer_filters
 					 * @param  {array<string>} $filters Default filters
 					 * @return {array<string>} New filters

--- a/includes/mappings/post/pre-5-0.php
+++ b/includes/mappings/post/pre-5-0.php
@@ -32,7 +32,15 @@ return array(
 			'analyzer' => array(
 				'default'          => array(
 					'tokenizer' => 'standard',
-					'filter'    => array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ),
+					/**
+					 * Filter Elasticsearch default analyzer's filters
+					 *
+					 * @since 3.6.2
+					 * @hook ep_default_analyzer_filters
+					 * @param  {array<string>} $filters Default filters
+					 * @return {array<string>} New filters
+					 */
+					'filter' => apply_filters( 'ep_default_analyzer_filters', array( 'standard', 'ewp_word_delimiter', 'lowercase', 'stop', 'ewp_snowball' ) ),
 					/**
 					 * Filter Elasticsearch default language in mapping
 					 *


### PR DESCRIPTION
## Description
In order to adjust default analyzer filters, we introduced a WP filter vip_search_default_analyzer_filters.

For example to enable ascii folding on most fields (e.g. post_title, post_content):
```
	add_filter( 'ep_default_analyzer_filters', function ( $filters ) {
			return  array( 'ewp_word_delimiter', 'lowercase', 'stop', 'asciifolding', 'ewp_snowball' );
}
		);
```



## Steps to Test

1. Create a post with tittle "Hamburger"
2. Create a post with tittle "Hàmburger"
3. Add the filter from the example above
4. Reindex all the posts using new mappings - `vip dev-env exec -- wp vip-search index --setup`
5. Search for both Hamburger and Hàmburger should return BOTH posts.


