### PR TITLE
Removing duplicate call to delete post

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -380,14 +380,6 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		/**
-		 * Fires before post deletion
-		 *
-		 * @hook ep_delete_post
-		 * @param  {int} $post_id ID of post
-		 */
-		do_action( 'ep_delete_post', $post_id );
-
 		Indexables::factory()->get( $this->indexable_slug )->delete( $post_id, false );
 
 		/**


### PR DESCRIPTION
## Description

When a post is deleted in ElasticPress, we see that two queries are sent to Elasticsearch to delete that post. Since they are duplicated, at least one of those queries always fails. This happens because we are sending the `ep_delete_post` signal twice. 

This PR gets rid of that duplication.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. Delete a post.
3. See that the post is correctly removed from the index.