### PR TITLE
Add custom Widget title and description

### DIFF
--- a/includes/classes/Feature/Facets/Widget.php
+++ b/includes/classes/Feature/Facets/Widget.php
@@ -23,8 +23,9 @@ class Widget extends WP_Widget {
 	 * Create widget
 	 */
 	public function __construct() {
-		$options = array( 'description' => esc_html__( 'Add a facet to an archive or search results page.', 'elasticpress' ) );
-		parent::__construct( 'ep-facet', esc_html__( 'ElasticPress - Facet', 'elasticpress' ), $options );
+		// Forking name and description of the widget to better fit within VIP
+		$options = array( 'description' => esc_html__( 'Add a facet (filter) to an archive or search results page.', 'elasticpress' ) );
+		parent::__construct( 'ep-facet', esc_html__( 'Enterprise Search - Filters', 'elasticpress' ), $options );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR customizes the Elasticpress' Facets widget title and description to better match Enterprise Search naming and discoverability of functions.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
2. Go to `wp-admin` > `Widgets`
3. Verify that the widget has the `Enterprise Search` name.