### PR TITLE
Fix bulk indexing resetting to the OFFSET pagination mode and thus making things SLOOOOOOOOOOW

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1019,9 +1019,11 @@ class Command extends WP_CLI_Command {
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 				}
+			// Offset is only needed in nobulk mode.
+			} else {
+				$query_args['offset'] += $per_page;
 			}
 
-			$query_args['offset']                              += $per_page;
 			$total_indexable                                    = (int) $query['total_objects'];
 			$query_args['ep_indexing_last_processed_object_id'] = $last_processed_object_id;
 

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1019,8 +1019,10 @@ class Command extends WP_CLI_Command {
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 				}
-			// Offset is only needed in nobulk mode.
 			} else {
+				// Only increment the offset if not using advanced pagination.
+				// For the advanced pagination should always be 0.
+				// @see Indexable\Post\Post.php::query_db.
 				$query_args['offset'] += $per_page;
 			}
 


### PR DESCRIPTION
## Description

After one of the recent upstream merges, a regression was introduced that effectively kicked the range-based pagination into the old OFFSET mode, which doesn't work great with large amounts of context. 

The culprit is `Indexable\Post`: 

```
		if ( isset( $args['include'] ) || isset( $args['post__in'] ) || 0 < $args['offset'] ) {
			// Disable advanced pagination. Not useful if only indexing specific IDs.
			$args['ep_indexing_advanced_pagination'] = false;
		}
```

https://github.com/Automattic/ElasticPress/blob/develop/includes/classes/Indexable/Post/Post.php#L90-L93

To address the issue we only update offset when the command runs in the "nobulk" mode.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Run `wp vip-search index` on a large site
2. Observe how `Time elapsed` gets progressively larger
3. Apply the PR 
4. Re-run the command
5. Observe near-constant `Time elapsed`
6. Rejoice.