### PR TITLE
Force fetching ep_wpcli_sync_interrupted transient from remote to allow for more reliable remote interruption

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1635,7 +1635,11 @@ class Command extends WP_CLI_Command {
 		global $wpdb;
 
 		if ( wp_using_ext_object_cache() ) {
-			$should_interrupt_sync = wp_cache_get( $transient, 'transient' );
+			/**
+			* When external object cache is used we need to make sure to force a remote fetch,
+			* so that the value from the local memory is discarded.
+			*/
+			$should_interrupt_sync = wp_cache_get( $transient, 'transient', true );
 		} else {
 			$options = $wpdb->options;
 


### PR DESCRIPTION

## Description

During some testing, it was discovered that `wp vip-search stop-indexing` doesn't reliably terminate the execution of an already-running process. 

I _think_ this is due to the cache value being stuck in local memory, this should help to prevent that by always forcing the remote fetch from the object cache backend.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

1. Check out PR.
1. Spin up an indexing process in a memcached-enabled environment
1. Run  `wp vip-search stop-indexing` from another session
1. Repeat the process and verify it gets interrupted properly.

