### PR TITLE
Add maximum value for per-page option during indexing

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -855,7 +855,7 @@ class Command extends WP_CLI_Command {
 		$per_page = $indexable->get_bulk_items_per_page();
 
 		if ( ! empty( $args['per-page'] ) ) {
-			$query_args['per_page'] = absint( $args['per-page'] );
+			$query_args['per_page'] = min( absint( $args['per-page'] ), 5000 );
 			$per_page               = $query_args['per_page'];
 		} else {
 			$query_args['per_page'] = $per_page;


### PR DESCRIPTION
## Description
We should add a limit to the `--per-page` option during indexing so users cannot use yuge values like 999999. Let's use `5000` because that seems to be 10x the default (500) and doesn't get killed on VIP Go: https://docs.wpvip.com/how-tos/vip-search/search-debugging-tips/#h-search-query-is-not-being-offloaded-to-enterprise-search.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1) Use a site with over 10000 posts
2) Pass in `wp vip-search index --per-page=9999999999999`
3) Notice that it only indexes 5000 at once per cycle.