### PR TITLE
Fix typo for "stopping" in output for stop-indexing

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1512,7 +1512,7 @@ class Command extends WP_CLI_Command {
 		if ( empty( \ElasticPress\Utils\get_indexing_status() ) ) {
 			WP_CLI::warning( esc_html__( 'There is no indexing operation running.', 'elasticpress' ) );
 		} else {
-			WP_CLI::line( esc_html__( 'Stoping indexing...', 'elasticpress' ) );
+			WP_CLI::line( esc_html__( 'Stopping indexing...', 'elasticpress' ) );
 
 			if ( isset( $indexing_status['method'] ) && 'cli' === $indexing_status['method'] ) {
 				set_transient( 'ep_wpcli_sync_interrupted', true, 5 );


### PR DESCRIPTION

## Description
Current output for `wp vip-search stop-indexing` returns this message:

```
Stoping indexing...
Success: Done.
```

Stoping -> Stopping

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1) Start an indexing operation with `wp vip-search index`
2) Attempt to stop it with `wp vip-search stop-indexing` and see the "stopping" with the extra p.