### PR TITLE
Disable advanced pagination for include command option and explicitly only offset when there is no advanced pagination

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1018,7 +1018,9 @@ class Command extends WP_CLI_Command {
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 				}
-			} else {
+			}
+
+			if ( ! $query_args['ep_indexing_advanced_pagination'] ) {
 				// Only increment the offset if not using advanced pagination.
 				// For the advanced pagination should always be 0.
 				// @see Indexable\Post\Post.php::query_db.

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -847,9 +847,10 @@ class Command extends WP_CLI_Command {
 		}
 
 		if ( ! empty( $args['include'] ) ) {
-			$include               = explode( ',', str_replace( ' ', '', $args['include'] ) );
-			$query_args['include'] = array_map( 'absint', $include );
-			$args['per-page']      = count( $query_args['include'] );
+			$include                                       = explode( ',', str_replace( ' ', '', $args['include'] ) );
+			$query_args['include']                         = array_map( 'absint', $include );
+			$args['per-page']                              = count( $query_args['include'] );
+			$query_args['ep_indexing_advanced_pagination'] = false;
 		}
 
 		$per_page = $indexable->get_bulk_items_per_page();


### PR DESCRIPTION
## Description
When you use the `--include` flag with the indexing CLI command, it ends up doing an infinite loop.

Introduced in https://github.com/Automattic/ElasticPress/pull/106.

This PR does two things:
1) it disables advanced pagination when the include command option is used, which is in line with what is done in `query_db()` later on: https://github.com/Automattic/ElasticPress/blob/9f914d59a941052c8a3773d69b7a7b1f5479cc71/includes/classes/Indexable/Post/Post.php#L90-L93 
...except we need to account for it in the CLI as well: https://github.com/Automattic/ElasticPress/blob/aaff27acae972dac29e8d954bdabbfc8e6cc2399/includes/classes/Command.php#L1024
2) We explicitly state to only use the offset if advanced pagination is disabled.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1) kick off an index job with the `--include`: `wp vip-search index --include=7,18`
2) see it do an infinite loop, i.e.

```
Indexing posts...
Processed 2/2. Last Object ID: 10
Processed 4/2. Last Object ID: 10
Processed 6/2. Last Object ID: 10
Processed 8/2. Last Object ID: 10
Processed 10/2. Last Object ID: 10
Processed 12/2. Last Object ID: 10
Processed 14/2. Last Object ID: 10
Processed 16/2. Last Object ID: 10
Processed 18/2. Last Object ID: 10
Processed 20/2. Last Object ID: 10
Time elapsed: 0.37
Memory Usage: 60.2mb (Peak: 61.51mb)
...
Processed 48/2. Last Object ID: 10
Processed 50/2. Last Object ID: 10
Processed 52/2. Last Object ID: 10
```

3) stop the command
4) delete any leftover transients `wp vip-search delete-transient`
5) apply PR
6) repeat step 1 and see it complete:

```
Indexing posts...
Processed 2/2. Last Object ID: 7
Number of posts indexed: 2
Total time elapsed: 0.095
Success: Done!
```