### PR TITLE
Fix non-post indexing

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -828,7 +828,7 @@ class Command extends WP_CLI_Command {
 		$query_args = [];
 
 		$query_args['offset']                          = 0;
-		$query_args['ep_indexing_advanced_pagination'] = 'post' === $indexable->slug && ! $no_bulk;
+		$query_args['ep_indexing_advanced_pagination'] = ! $no_bulk;
 
 		if ( ! empty( $args['offset'] ) ) {
 			$query_args['offset'] = absint( $args['offset'] );

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -830,7 +830,7 @@ class Command extends WP_CLI_Command {
 		$query_args = [];
 
 		$query_args['offset']                          = 0;
-		$query_args['ep_indexing_advanced_pagination'] = ! $no_bulk;
+		$query_args['ep_indexing_advanced_pagination'] = 'post' === $indexable->slug && ! $no_bulk;
 
 		if ( ! empty( $args['offset'] ) ) {
 			$query_args['offset'] = absint( $args['offset'] );
@@ -1019,7 +1019,9 @@ class Command extends WP_CLI_Command {
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 				}
-			} else {
+			}
+
+			if ( ! $query_args['ep_indexing_advanced_pagination'] ) {
 				// Only increment the offset if not using advanced pagination.
 				// For the advanced pagination should always be 0.
 				// @see Indexable\Post\Post.php::query_db.

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -737,8 +737,17 @@ class User extends Indexable {
 		/**
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
+		 *
+		 * The $wpdb->prepare will quate placeholders.
+		 *
+		 * SELECT * FROM table 'ORDER BY col asc'; - mariadb (vipd and local dev-env) doesn't like that
+		 * SELECT * FROM table ORDER BY 'col' 'asc'; - (this is the upstream variant) Vitess (k8s) doesn't like that
+		 *
+		 * We are sanitizing orderby in advance and putting it as a varible to avoid quates.
 		 */
+		// @codingStandardsIgnoreStart
 		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );
+		// @codingStandardsIgnoreStop
 
 		return [
 			'objects'       => $objects,

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -738,12 +738,8 @@ class User extends Indexable {
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 *
-		 * The $wpdb->prepare will quate placeholders.
-		 *
-		 * SELECT * FROM table 'ORDER BY col asc'; - mariadb (vipd and local dev-env) doesn't like that
-		 * SELECT * FROM table ORDER BY 'col' 'asc'; - (this is the upstream variant) Vitess (k8s) doesn't like that
-		 *
-		 * We are sanitizing orderby in advance and putting it as a varible to avoid quates.
+		 * The $wpdb->prepare will quote placeholders.
+		 * We are sanitizing orderby in advance and putting it as a variable to avoid quotes.
 		 */
 		// @codingStandardsIgnoreStart
 		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );

--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -738,7 +738,7 @@ class User extends Indexable {
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 */
-		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} %s LIMIT %d, %d", $orderby, (int) $args['offset'], (int) $args['number'] ) );
+		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );
 
 		return [
 			'objects'       => $objects,


### PR DESCRIPTION
### Description of the Change

When testing https://github.com/Automattic/ElasticPress/pull/111 I found that the offset problem is more widespread. This fixes the infinite loop for other indexable.

Introduced in #106 

Also, the current version of the users query that was recently [changed](https://github.com/Automattic/ElasticPress/pull/97/files) is not supported with mariadb `mariadb:10.3.27-debian-10-r84 ` image we use in local dev-env.

cc @brettshumaker 

## Test steps

1) Enable user feature `vip dev-env exec -- wp elasticpress activate-feature users`
2) `vip dev-env exec -- wp vip-search index --indexables=user` succeeds