### PR TITLE
suppress warning thrown on DateTime

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -487,6 +487,12 @@ abstract class Indexable {
 		$meta_types['datetime'] = '1970-01-01 00:00:01';
 		$meta_types['time']     = '00:00:01';
 
+		// hide the warning the is emitted by \DateTime.
+		// @see: http://php.net/manual/en/datetime.construct.php#116480
+		// @see: https://stackoverflow.com/questions/45856223/can-i-avoid-datetime-construct-warning-on-invalid-date
+		$oldErrorReporting = error_reporting();
+		error_reporting( $oldErrorReporting & ~E_WARNING );
+
 		try {
 			// is this is a recognizable date format?
 			$new_date  = new \DateTime( $meta_value, \wp_timezone() );
@@ -504,6 +510,9 @@ abstract class Indexable {
 			// if $meta_value is not a recognizable date format, DateTime will throw an exception,
 			// just catch it and move on.
 		}
+
+		// reset error reporting.
+		error_reporting( $oldErrorReporting );
 
 		return $meta_types;
 	}


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description

Fix a New Relic warning that is thrown at very high frequency.

![image](https://user-images.githubusercontent.com/9660445/131771288-4e845667-a95c-42af-9658-c0f14b8bf902.png)
![image](https://user-images.githubusercontent.com/9660445/131771476-983dc309-e5a6-4ee9-96fc-7cf7f50f7733.png)

> If time cannot be parsed an exception of type Exception is thrown which can be caught, however an E_WARNING is emitted as well.
- http://php.net/manual/en/datetime.construct.php#116480

Also see: https://stackoverflow.com/questions/45856223/can-i-avoid-datetime-construct-warning-on-invalid-date

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1. Check out PR.
1. Go to `wp-admin` > `Articles`
1. Save / Update a post to trigger indexing.
1. Verify E_WARNING is not emitted to New Relic.
