### PR TITLE
Clean advanced pagination logic

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -87,7 +87,7 @@ class Post extends Indexable {
 		 */
 		$args = apply_filters( 'ep_index_posts_args', apply_filters( 'ep_post_query_db_args', wp_parse_args( $args, $defaults ) ) );
 
-		if ( isset( $args['include'] ) || isset( $args['post__in'] ) || 0 < $args['offset'] ) {
+		if ( isset( $args['include'] ) || isset( $args['post__in'] ) ) {
 			// Disable advanced pagination. Not useful if only indexing specific IDs.
 			$args['ep_indexing_advanced_pagination'] = false;
 		}

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5439,16 +5439,6 @@ class TestPost extends BaseTestCase {
 
 		$this->assertCount( 0, $results['objects'] );
 		$this->assertEquals( 3, $results['total_objects'] );
-
-		$results = $indexable_post_object->query_db(
-			[
-				'offset' => -1,
-				'ep_indexing_advanced_pagination' => false,
-			]
-		);
-
-		$this->assertCount( 3, $results['objects'] );
-		$this->assertEquals( 3, $results['total_objects'] );
 	}
 
 	/**

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5421,6 +5421,7 @@ class TestPost extends BaseTestCase {
 		$results = $indexable_post_object->query_db(
 			[
 				'offset' => 1,
+				'ep_indexing_advanced_pagination' => false,
 			]
 		);
 
@@ -5432,6 +5433,7 @@ class TestPost extends BaseTestCase {
 		$results = $indexable_post_object->query_db(
 			[
 				'offset' => 3,
+				'ep_indexing_advanced_pagination' => false,
 			]
 		);
 
@@ -5441,6 +5443,7 @@ class TestPost extends BaseTestCase {
 		$results = $indexable_post_object->query_db(
 			[
 				'offset' => -1,
+				'ep_indexing_advanced_pagination' => false,
 			]
 		);
 


### PR DESCRIPTION
Primarily, the goal here is to leave as much responsibility as possible to the specific "Post indexable class" when it comes to advanced pagination. So we don't unnecessarily interfere with other indexables right now.

1) So on that note, we do not need to explicitly enable advanced pagination so early. We can explicitly disable it if an offset is passed in, but no need to go any further than that. Can then continue always incrementing the offset, as it's already being dealt with correctly when advanced pagination is left enabled.

2) Resolves the original issue with `--nobulk` by passing the correct `$last_processed_object_id` no matter what. Advanced pagination can work just fine with nobulk.

Testing:

```
wp vip-search index
wp vip-search index --nobulk
wp vip-search index --include=76,77
wp vip-search index --offset=100

// Also needs the `Indexable/User/User.php` fixes from https://github.com/Automattic/ElasticPress/pull/112
 wp elasticpress activate-feature users
 wp vip-search index --indexables=user --nobulk
 wp vip-search index --indexables=user --offset=100
```