### PR TITLE
Use date_Create that does not throw exception or warning

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -487,9 +487,9 @@ abstract class Indexable {
 		$meta_types['datetime'] = '1970-01-01 00:00:01';
 		$meta_types['time']     = '00:00:01';
 
-		try {
-			// is this is a recognizable date format?
-			$new_date  = new \DateTime( $meta_value, \wp_timezone() );
+		// is this is a recognizable date format?
+		$new_date  = date_create( $meta_value, \wp_timezone() );
+		if ( $new_date ) {
 			$timestamp = $new_date->getTimestamp();
 
 			// PHP allows DateTime to build dates with the non-existing year 0000, and this causes
@@ -500,9 +500,6 @@ abstract class Indexable {
 				$meta_types['datetime'] = $new_date->format( 'Y-m-d H:i:s' );
 				$meta_types['time']     = $new_date->format( 'H:i:s' );
 			}
-		} catch ( \Exception $e ) {
-			// if $meta_value is not a recognizable date format, DateTime will throw an exception,
-			// just catch it and move on.
 		}
 
 		return $meta_types;


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description
This is inspired by https://github.com/Automattic/ElasticPress/pull/113


It seems that `new \DateTime( $meta_value, \wp_timezone() );` throws not only exception but also a `E_WARNING` in certain cases.

There is the `date_create` alternative, that according to [manual](https://www.php.net/manual/en/function.date-create.php) is an alias. While testing it though I found it, it returns false on faileru and does **NOT** throw an exception or warning (as far as I can see).

There are already unittests covering this function that are passing and also testing on the local dev-environment results in good results.


## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
