### PR TITLE
Separate out ep_set_default_sort to work with CLI and search results

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -896,12 +896,12 @@ class Post extends Indexable {
 			/**
 			 * Filter default post query order by
 			 *
-			 * @hook ep_set_default_sort
-			 * @param  {string} $sort Default sort
+			 * @hook ep_set_default_orderby
+			 * @param  {string} $orderby Default orderby
 			 * @param  {string $order Order direction
 			 * @return  {string} New default
 			 */
-			$args['orderby'] = apply_filters( 'ep_set_default_sort', 'date', $order );
+			$args['orderby'] = apply_filters( 'ep_set_default_orderby', 'date', $order );
 		}
 
 		// Set sort type.
@@ -921,9 +921,9 @@ class Post extends Indexable {
 			 * Filter default post query order by
 			 *
 			 * @hook ep_set_default_sort
-			 * @param  {string} $sort Default sort
+			 * @param  {array} $sort Default sort
 			 * @param  {string} $order Order direction
-			 * @return  {string} New default
+			 * @return  {array} New default
 			 */
 			$default_sort = apply_filters( 'ep_set_default_sort', $default_sort, $order );
 


### PR DESCRIPTION
### Description of the Change

By default, search results are ordered by relevance score: https://github.com/Automattic/ElasticPress/blob/a796de781fe1c38f480fafc28636c0493a0ec4a6/includes/classes/Indexable/Post/Post.php#L881-L888

However, it is possible to adjust the default search results ordering via the filter `ep_set_default_sort`:

https://github.com/Automattic/ElasticPress/blob/a796de781fe1c38f480fafc28636c0493a0ec4a6/includes/classes/Indexable/Post/Post.php#L898

Hooking onto the filter using the `ep_sort_by_date` snippet below:

```
add_filter( 'ep_set_default_sort', 'ep_sort_by_date', 20, 2 );

function ep_sort_by_date( $sort, $order ) {
	return array(
				array(
					'post_date' => array(
						'order' => $order',
						),
					),
			);
}
```

Unfortunately, that breaks [parse_orderby()](https://github.com/Automattic/ElasticPress/blob/a796de781fe1c38f480fafc28636c0493a0ec4a6/includes/classes/Indexable/Post/Post.php#L1915) (which can be reproduced with running the CLI `wp vip-search health validate-counts`), as it is expecting a **string**, but a **nested array** is being passed in due to the filter being used differently on two occasions:

1) Expecting a string:

https://github.com/Automattic/ElasticPress/blob/a796de781fe1c38f480fafc28636c0493a0ec4a6/includes/classes/Indexable/Post/Post.php#L874-L879

2) Expecting a nested array:

https://github.com/Automattic/ElasticPress/blob/a796de781fe1c38f480fafc28636c0493a0ec4a6/includes/classes/Indexable/Post/Post.php#L881-L900

### Alternate Designs

We could re-factor `parse_orderby()` to account for nested arrays better instead of splitting it out into 2 filters, but I'm uncertain about side effects and changing that logic.

### Verification Process

1) See that default search results do not return chronologically by date
2) Apply `ep_sort_by_date` snippet above
3) See that default search results return chronologically by date
4) Run `wp vip-search health validate-counts` and see it work as expected

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Added: New filter ep_set_default_orderby for parse_orderby use

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
