### PR TITLE
Change delete term trigger

### DIFF
--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -192,10 +192,6 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		if ( ! current_user_can( 'delete_term', $term_id ) && ! apply_filters( 'ep_sync_delete_permissions_bypass', false, $term_id, 'term' ) ) {
-			return;
-		}
-
 		// Find all terms in the hierarchy so we resync those as well
 		$term      = get_term( $term_id );
 		$children  = get_term_children( $term->term_id, $term->taxonomy );
@@ -205,6 +201,10 @@ class SyncManager extends SyncManagerAbstract {
 		foreach ( $hierarchy as $hierarchy_term_id ) {
 			if ( apply_filters( 'ep_term_sync_kill', false, $hierarchy_term_id ) ) {
 				return;
+			}
+
+			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' )  ) {
+				continue;
 			}
 
 			do_action( 'ep_sync_term_on_transition', $hierarchy_term_id );

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -40,7 +40,7 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'added_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'deleted_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'updated_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
-		add_action( 'delete_term_taxonomy', [ $this, 'action_sync_on_delete' ] );
+		add_action( 'pre_delete_term', [ $this, 'action_sync_on_delete' ] );
 		add_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ], 10, 2 );
 	}
 
@@ -185,10 +185,6 @@ class SyncManager extends SyncManagerAbstract {
 		$hierarchy = array_merge( $ancestors, $children );
 
 		foreach ( $hierarchy as $hierarchy_term_id ) {
-			if ( ! current_user_can( 'edit_term', $hierarchy_term_id ) ) {
-				return;
-			}
-
 			if ( apply_filters( 'ep_term_sync_kill', false, $hierarchy_term_id ) ) {
 				return;
 			}

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -203,7 +203,7 @@ class SyncManager extends SyncManagerAbstract {
 				return;
 			}
 
-			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' )  ) {
+			if ( ! current_user_can( 'edit_term', $term_id ) && ! apply_filters( 'ep_sync_insert_permissions_bypass', false, $term_id, 'term' ) ) {
 				continue;
 			}
 

--- a/includes/classes/Indexable/Term/SyncManager.php
+++ b/includes/classes/Indexable/Term/SyncManager.php
@@ -40,7 +40,7 @@ class SyncManager extends SyncManagerAbstract {
 		add_action( 'added_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'deleted_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
 		add_action( 'updated_term_meta', [ $this, 'action_queue_meta_sync' ], 10, 2 );
-		add_action( 'delete_term', [ $this, 'action_sync_on_delete' ] );
+		add_action( 'delete_term_taxonomy', [ $this, 'action_sync_on_delete' ] );
 		add_action( 'set_object_terms', [ $this, 'action_sync_on_object_update' ], 10, 2 );
 	}
 


### PR DESCRIPTION
### Description of the Change

Deleting term needs to do 2 actions:
* Delete the term
* Reindex all the child terms

However, if the hook is invoked on `delete_term` the term is already deleted in WP by then. The operations needed to get the list of child terms then fails. 

This change switches the two actions into 2 hooks. On `pre_delete_term` which happens both before the term is deleted but also before the child terms were updated in WP already, we will enqueue child terms to sync queue. Then on `delete_term` (same as before) we will remove the term from ES.

The sync queue is then processed on shutdown, that is after the children terms were already updated with the correct parent.

Another change in this PR is adding the permission check bypass for CLI and cron on term resyncing.

### Test steps

1) `dev-env exec -- wp elasticpress activate-feature terms`
2)  `dev-env exec -- wp vip-search index --setup`
3) Create some hierarchy of categories
4) Delete middle one `dev-env exec -- wp term delete category <ID of term that has children>

5) No errors
5) Term is deleted
5) Check that index is correctly showing the children of deleted term pointing to the parent of deleted term as their parent now



