### PR TITLE
Fix incorrect invocation of is_callable()

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1241,7 +1241,7 @@ class Command extends WP_CLI_Command {
 				wp_cache_flush();
 			}
 
-			if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+			if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 				call_user_func( [ $wp_object_cache, '__remoteset' ] );
 			}
 		}


### PR DESCRIPTION
## Description

This PR fixes the incorrect invocation of `is_callable()` in `Command::stop_the_insanity()`.

Since `WP_Object_Cache` does not have the `__invoke()` method, `is_callable( $wp_object_cache, true )` (`'__remoteset'` is coerced into `true`) always returns `false`.

Related: Automattic/vip-go-mu-plugins#2489

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test

N/A — I failed to find an object cache plugin with `__remoteset` method. Without it, the behavior of the code should not change as both the old and the new condition evaluate to `false`.
