### PR TITLE
Search feature: account for multisite in is_synonym_page()

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -605,7 +605,7 @@ class Synonyms {
 		}
 
 		$screen = get_current_screen();
-		$base   = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page' : 'elasticpress_page' ) . '_elasticpress-synonyms';
+		$base   = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin' : 'elasticpress' ) . '_page_elasticpress-synonyms';
 
 		return $base === $screen->base;
 	}

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -605,7 +605,9 @@ class Synonyms {
 		}
 
 		$screen = get_current_screen();
-		return ( 'elasticpress_page_elasticpress-synonyms' === $screen->base );
+		$base = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page_elasticpress-synonyms' : 'elasticpress_page_elasticpress-synonyms';
+		
+		return $base === $screen->base;
 	}
 
 	/**

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -605,8 +605,8 @@ class Synonyms {
 		}
 
 		$screen = get_current_screen();
-		$base = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page_elasticpress-synonyms' : 'elasticpress_page_elasticpress-synonyms';
-		
+		$base   = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page_elasticpress-synonyms' : 'elasticpress_page_elasticpress-synonyms';
+
 		return $base === $screen->base;
 	}
 

--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -605,7 +605,7 @@ class Synonyms {
 		}
 
 		$screen = get_current_screen();
-		$base   = defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page_elasticpress-synonyms' : 'elasticpress_page_elasticpress-synonyms';
+		$base   = ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ? 'admin_page' : 'elasticpress_page' ) . '_elasticpress-synonyms';
 
 		return $base === $screen->base;
 	}


### PR DESCRIPTION
## Description
The synonyms settings page is broken when `EP_IS_NETWORK` is present due to having a different screen base slug.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
0) Check out PR
1) On a multi-site, enable the `EP_IS_NETWORK` constant
2) Go to `/wp-admin/admin.php?page=elasticpress-synonyms`.
3) See it render as expected.

Note: This does not affect upstream. This only occurs because we currently disable the UI.