### PR TITLE
Load admin styles for Search feature pages of subsites in multisite instance

### DIFF
--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -43,14 +43,8 @@ class Screen {
 	 */
 	public function determine_screen() {
 		// If in network mode, don't output notice in admin and vice-versa.
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			if ( ! is_network_admin() ) {
-				return false;
-			}
-		} else {
-			if ( is_network_admin() ) {
-				return false;
-			}
+		if ( ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) && is_network_admin() ) {
+			return false;
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification

--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -42,9 +42,7 @@ class Screen {
 	 * @since 3.0
 	 */
 	public function determine_screen() {
-		if ( ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) && is_network_admin() ) {
-			return false;
-		}
+		// VIP: We removed the block about returning false depending on network admin or in network mode && not network admin
 
 		// phpcs:disable WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['page'] ) && false !== strpos( $_GET['page'], 'elasticpress' ) ) {

--- a/includes/classes/Screen.php
+++ b/includes/classes/Screen.php
@@ -42,7 +42,6 @@ class Screen {
 	 * @since 3.0
 	 */
 	public function determine_screen() {
-		// If in network mode, don't output notice in admin and vice-versa.
 		if ( ( ! defined( 'EP_IS_NETWORK' ) || ! EP_IS_NETWORK ) && is_network_admin() ) {
 			return false;
 		}

--- a/tests/php/TestScreen.php
+++ b/tests/php/TestScreen.php
@@ -88,12 +88,7 @@ class TestScreen extends BaseTestCase {
 
 		ElasticPress\Screen::factory()->determine_screen();
 
-		// This will be 'install' for single site, but null for multisite.
-		if ( is_multisite() ) {
-			$this->assertNull( ElasticPress\Screen::factory()->get_current_screen() );
-		} else {
-			$this->assertSame( 'install', ElasticPress\Screen::factory()->get_current_screen() );
-		}
+		$this->assertSame( 'install', ElasticPress\Screen::factory()->get_current_screen() );
 	}
 
 	/**

--- a/tests/php/TestScreen.php
+++ b/tests/php/TestScreen.php
@@ -88,6 +88,7 @@ class TestScreen extends BaseTestCase {
 
 		ElasticPress\Screen::factory()->determine_screen();
 
+		// VIP: We changed logic for determine_screen() to load, so do not test for multisite
 		$this->assertSame( 'install', ElasticPress\Screen::factory()->get_current_screen() );
 	}
 


### PR DESCRIPTION
## Description

Related to https://github.com/Automattic/ElasticPress/pull/123. 

The proper styles are not loaded for the Search feature pages (i.e. `wp-admin/admin.php?page=elasticpress-synonyms` or `wp-admin/admin.php?page=elasticpress-weighting`) when `EP_IS_NETWORK` is set to true because of this block returning early: https://github.com/Automattic/ElasticPress/blob/bac3d3bc59341b35781254a9558abc29089c8a0a/includes/classes/Screen.php#L46-L54

Therefore, the below check fails: https://github.com/Automattic/ElasticPress/blob/e1c76c2fc7d78f04490126bb54b15aa3fa1b5089/includes/dashboard.php#L786-L788

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
1) Check out PR
2) Visit one of the Search feature pages, i.e. `wp-admin/admin.php?page=elasticpress-synonyms`
3) See proper styling applied (i.e. settings button on right side instead of left side)
