### PR TITLE
Fix 299 Specifying types in multi get requests is deprecated warning

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -663,7 +663,7 @@ class Elasticsearch {
 		if ( version_compare( $this->get_elasticsearch_version(), '7.0', '<' ) ) {
 			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/' . $type . '/_mget', $document_ids, $type );
 		} else {
-			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/_doc/_mget', $document_ids, $type );
+			$path = apply_filters( 'ep_index_' . $type . '_request_path', $index . '/_mget', $document_ids, $type );
 		}
 
 		$request_args = [


### PR DESCRIPTION
This is a cherry-pick for the PR that was submitted upstream https://github.com/10up/ElasticPress/pull/2397/ against our develop
 
