### PR TITLE
Bump EP_ES_VERSION_MAX to 7.10.2

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -74,7 +74,7 @@ spl_autoload_register(
  *
  * @since  2.2
  */
-define( 'EP_ES_VERSION_MAX', '7.9' );
+define( 'EP_ES_VERSION_MAX', '7.10.2' );
 define( 'EP_ES_VERSION_MIN', '5.0' );
 
 require_once __DIR__ . '/includes/compat.php';


### PR DESCRIPTION
## Description

In prep to 7.10.2 upgrade, we need to bump the max tested version.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
