### PR TITLE
Account for offset in result window limitation

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -357,7 +357,7 @@ abstract class Indexable {
 	public function query_es( $formatted_args, $query_args, $index = null, $query_object = null ) {
 		// VIP: If result window is too big, we avoid doing a query that will fail
 		if ( isset( $formatted_args['from'] ) && isset( $formatted_args['size'] ) ) {
-			$result_window     = $formatted_args['size'] - $formatted_args['from'];
+			$result_window     = $formatted_args['from'] + $formatted_args['size'];
 			$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
 			if ( $result_window > $max_result_window ) {
 				return false;

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -356,8 +356,8 @@ abstract class Indexable {
 	 */
 	public function query_es( $formatted_args, $query_args, $index = null, $query_object = null ) {
 		// VIP: If result window is too big, we avoid doing a query that will fail
-		if ( array_key_exists( 'from', $formatted_args ) && array_key_exists( 'size', $formatted_args ) ) {
-			$result_window     = $formatted_args['from'] + $formatted_args['size'];
+		if ( isset( $formatted_args['from'] ) && isset( $formatted_args['size'] ) ) {
+			$result_window     = $formatted_args['size'] - $formatted_args['from'];
 			$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
 			if ( $result_window > $max_result_window ) {
 				return false;

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -86,7 +86,7 @@ class Comment extends Indexable {
 		if ( isset( $query_vars['offset'] ) ) {
 			$formatted_args['from'] = (int) $query_vars['offset'];
 			if ( empty( $query_vars['number'] ) ) {
-				$formatted_args['size'] -= $formatted_args['from'];
+				$formatted_args['size'] -= (int) $formatted_args['from'];
 			}
 		}
 

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -85,6 +85,10 @@ class Comment extends Indexable {
 		 */
 		if ( isset( $query_vars['offset'] ) ) {
 			$formatted_args['from'] = (int) $query_vars['offset'];
+			// VIP: If we are using the default max result window value for size, we should account for offset
+			if ( empty( $query_vars['number'] ) ) {
+				$formatted_args['size'] -= $formatted_args['from'];
+			}
 		}
 
 		/**

--- a/includes/classes/Indexable/Comment/Comment.php
+++ b/includes/classes/Indexable/Comment/Comment.php
@@ -85,7 +85,6 @@ class Comment extends Indexable {
 		 */
 		if ( isset( $query_vars['offset'] ) ) {
 			$formatted_args['from'] = (int) $query_vars['offset'];
-			// VIP: If we are using the default max result window value for size, we should account for offset
 			if ( empty( $query_vars['number'] ) ) {
 				$formatted_args['size'] -= $formatted_args['from'];
 			}


### PR DESCRIPTION
## Description
Fixes test described in https://github.com/Automattic/ElasticPress/pull/129#issuecomment-961333889. 

Basically, comment queries with an offset passed in will never get offloaded to ES. This is because `query_es()` returns false the minute you pass in offset: https://github.com/Automattic/ElasticPress/blob/77907388b1b5473dc1070f8dce7e59bd2a0f43f7/includes/classes/Indexable/Comment/QueryIntegration.php#L153

This occurs because the default max size gets assigned in `format_args()` if no size has been explicitly passed in: https://github.com/Automattic/ElasticPress/blob/77907388b1b5473dc1070f8dce7e59bd2a0f43f7/includes/classes/Indexable/Comment/Comment.php#L75-L81

This is called from `maybe_filter_query()`: https://github.com/Automattic/ElasticPress/blob/77907388b1b5473dc1070f8dce7e59bd2a0f43f7/includes/classes/Indexable/Comment/QueryIntegration.php#L116

Therefore, the below check will always return `false` when an offset is passed in for comment queries:
https://github.com/Automattic/ElasticPress/blob/77907388b1b5473dc1070f8dce7e59bd2a0f43f7/includes/classes/Indexable.php#L358-L365

Instead, we should be subtracting the offset from size if we decide to use the default maximum window for it.

Bonus: I decided to change `array_key_exists()` to `isset()` since it's a bit faster. 

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
0) Check out PR
1) Do the below comment query:
```
	$comments_query = new \WP_Comment_Query( [
		'ep_integrate' => 1,
		'offset' => 3,
	] );
```
2) Ensure that the `elasticsearch_success` property in `$comments_query` returns `true`