### PR TITLE
drop custom taxonomies exclusion

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1011,11 +1011,6 @@ class Post extends Indexable {
 		);
 
 		foreach ( $taxonomies as $tax_slug => $tax ) {
-			// VIP: check agains our protected parameters. TODO: We should move that out to `ep_post_tax_excluded_wp_query_root_check` filter and outside of EP code
-			if ( 'ep_custom_result' === $tax_slug || $this->is_protected_parameter( $tax_slug ) ) {
-				continue;
-			}
-
 			if ( $tax->query_var && ! empty( $args[ $tax->query_var ] ) && ! in_array( $tax->name, $excluded_tax_from_root_check, true ) ) {
 				$args['tax_query'][] = array(
 					'taxonomy' => $tax_slug,
@@ -2024,89 +2019,6 @@ class Post extends Indexable {
 		return $orderbys;
 	}
 
-	/**
-	 * Check if a value matches a protected parameter
-	 *
-	 * @see https://developer.wordpress.org/reference/classes/wp_query/#parameters List of protected parameters
-	 *
-	 * @param string $value The value to test
-	 * @since 3.4
-	 * @return bool
-	 */
-	private function is_protected_parameter( $value ) {
-		if ( ! is_string( $value ) ) {
-			return false;
-		}
-
-		$protected_parameter_list = array(
-			'author',
-			'author__in',
-			'author__not_in',
-			'author_id',
-			'author_name',
-			'cache_results',
-			'cat',
-			'category__and',
-			'category__in',
-			'category__not_in',
-			'category_name',
-			'comment_count',
-			'date_query',
-			'day',
-			'fields',
-			'has_password',
-			'hour',
-			'ignore_sticky_posts',
-			'm',
-			'meta_compare',
-			'meta_key',
-			'meta_query',
-			'meta_value',
-			'meta_value_num',
-			'minute',
-			'monthnum',
-			'name',
-			'nopaging',
-			'offset',
-			'order',
-			'orderby',
-			'p',
-			'page',
-			'page_id',
-			'paged',
-			'pagename',
-			'perm',
-			'post__in',
-			'post__not_in',
-			'post_mime_type',
-			'post_name__in',
-			'post_parent',
-			'post_parent__in',
-			'post_parent__not_in',
-			'post_password',
-			'post_status',
-			'post_type',
-			'posts_per_archive_page',
-			'posts_per_page',
-			's',
-			'second',
-			'tag',
-			'tag__and',
-			'tag__in',
-			'tag__not_in',
-			'tag_id',
-			'tag_slug__and',
-			'tag_slug__in',
-			'tax',
-			'tax_query',
-			'update_post_meta_cache',
-			'update_post_term_cache',
-			'w',
-			'year',
-		);
-
-		return in_array( $value, $protected_parameter_list, true );
-	}
 	/**
 	 * Given a mapping content, try to determine the version used.
 	 *


### PR DESCRIPTION

## Description
This is a follow-up on https://github.com/Automattic/vip-go-mu-plugins/pull/2610

This drops the diverged code we have in our fork.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test

See - https://github.com/Automattic/vip-go-mu-plugins/pull/2610 for details
