### PR TITLE
Return back admin notice for incorrect mapping version

### DIFF
--- a/includes/classes/AdminNotices.php
+++ b/includes/classes/AdminNotices.php
@@ -41,10 +41,7 @@ class AdminNotices {
 		'upgrade_sync',
 		'auto_activate_sync',
 		'using_autosuggest_defaults',
-		/**
-		 * We don't want to notify for 'maybe_wrong_mapping', as that would
-		 * notify any site indexed bofore introduction of the mapping version meta
-		 */
+		'maybe_wrong_mapping',
 		'yellow_health',
 	];
 


### PR DESCRIPTION
## Description
A few versions back we removed the `incorrect mapping version` notice as it incorrectly detected the version mismatch.

This was fixed by 10up, so we can reenable notice for the cases when for some weird reason users end up with the incorrect index.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1. Login to admin bar.
2. Look for this notice:

![image](https://user-images.githubusercontent.com/19240162/142431972-249275e9-543c-411b-a4f0-d016d8100748.png)

3. To make it appear you can change [this function](https://github.com/Automattic/ElasticPress/blob/fef833793a85e0229bf6fa3f66ba75333f00d8c8/includes/classes/Indexable/Post/Post.php#L2031) to return other value - e.g. `return '3.0';`
4. Also a good test is to remove the first few tests relying on meta fields. The previous issue was in the scenario where the meta fields were not set. Even after removing these (first 2 if conditions) you should still NOT get the notice as the version should be correctly detected and match the expected.
