### PR TITLE
Fix overzealous filtering in Synonyms.php

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -390,7 +390,7 @@ class Synonyms {
 		$post_id = false;
 
 		if ( wp_verify_nonce( $nonce, $this->get_nonce_action() ) ) {
-			$synonyms = filter_input( INPUT_POST, $this->get_synonym_field(), FILTER_SANITIZE_SPECIAL_CHARS );
+			$synonyms = filter_input( INPUT_POST, $this->get_synonym_field(), FILTER_CALLBACK, [ 'options' => 'wp_strip_all_tags' ] );
 			$mode     = filter_input( INPUT_POST, 'synonyms_editor_mode', FILTER_SANITIZE_SPECIAL_CHARS );
 			$content  = trim( sanitize_textarea_field( $synonyms ) );
 


### PR DESCRIPTION
## Description

Fix overzealous filtering in Synonyms.php - it was not a good idea to encode HTML entities.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.
