### PR TITLE
Add backfill of 'ep_feature_settings' option

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -117,10 +117,10 @@ class Command extends WP_CLI_Command {
 			WP_CLI::error( esc_html__( 'No feature with that slug is registered', 'elasticpress' ) );
 		}
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$active_features = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$active_features = get_option( 'ep_feature_settings', [] );
+		// VIP: Every site should have its own option, rather than a network one.
+		$active_features = get_option( 'ep_feature_settings', [] );
+		if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+			$active_features = \vip_maybe_backfill_ep_option( $active_features, 'ep_feature_settings' );
 		}
 
 		$key = array_search( $feature->slug, array_keys( $active_features ), true );
@@ -150,11 +150,12 @@ class Command extends WP_CLI_Command {
 	public function list_features( $args, $assoc_args ) {
 
 		if ( empty( $assoc_args['all'] ) ) {
-			if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-				$features = get_site_option( 'ep_feature_settings', [] );
-			} else {
-				$features = get_option( 'ep_feature_settings', [] );
+			// VIP: Every site should have its own option, rather than a network one.
+			$features = get_option( 'ep_feature_settings', [] );
+			if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+				$features = \vip_maybe_backfill_ep_option( $features, 'ep_feature_settings' );
 			}
+
 			WP_CLI::line( esc_html__( 'Active features:', 'elasticpress' ) );
 
 			foreach ( array_keys( $features ) as $feature_slug ) {

--- a/includes/classes/Feature.php
+++ b/includes/classes/Feature.php
@@ -134,10 +134,10 @@ abstract class Feature {
 	 * @return array|bool
 	 */
 	public function get_settings() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
+		// VIP: Every site should have its own option, rather than a network one.
+		$feature_settings = get_option( 'ep_feature_settings', [] );
+		if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+			$feature_settings = \vip_maybe_backfill_ep_option( $feature_settings, 'ep_feature_settings' );
 		}
 
 		return ( ! empty( $feature_settings[ $this->slug ] ) ) ? $feature_settings[ $this->slug ] : false;
@@ -150,10 +150,10 @@ abstract class Feature {
 	 * @return boolean
 	 */
 	public function is_active() {
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
+		// VIP: Every site should have its own option, rather than a network one.
+		$feature_settings = get_option( 'ep_feature_settings', [] );
+		if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+			$feature_settings = \vip_maybe_backfill_ep_option( $feature_settings, 'ep_feature_settings' );
 		}
 
 		$active = false;

--- a/includes/classes/Features.php
+++ b/includes/classes/Features.php
@@ -105,10 +105,10 @@ class Features {
 
 		$original_state = $feature->is_active();
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', [] );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', [] );
+		// VIP: Every site should have its own option, rather than a network one.
+		$feature_settings = get_option( 'ep_feature_settings', [] );
+		if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+			$feature_settings = \vip_maybe_backfill_ep_option( $feature_settings, 'ep_feature_settings' );
 		}
 
 		if ( empty( $feature_settings[ $slug ] ) ) {
@@ -135,11 +135,8 @@ class Features {
 
 		$sanitize_feature_settings = apply_filters( 'ep_sanitize_feature_settings', $feature_settings, $feature );
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_feature_settings', $sanitize_feature_settings );
-		} else {
-			update_option( 'ep_feature_settings', $sanitize_feature_settings );
-		}
+		// VIP: Every site should have its own option, rather than a network one.
+		update_option( 'ep_feature_settings', $sanitize_feature_settings );
 
 		$data = array(
 			'reindex' => false,
@@ -210,10 +207,10 @@ class Features {
 		 * If feature settings aren't created, let's create them and finish
 		 */
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			$feature_settings = get_site_option( 'ep_feature_settings', false );
-		} else {
-			$feature_settings = get_option( 'ep_feature_settings', false );
+		// VIP: Every site should have its own option, rather than a network one.
+		$feature_settings = get_option( 'ep_feature_settings', false );
+		if ( function_exists( 'vip_maybe_backfill_ep_option' ) ) { // TODO: Remove
+			$feature_settings = \vip_maybe_backfill_ep_option( $feature_settings, 'ep_feature_settings' );
 		}
 
 		if ( false === $feature_settings ) {

--- a/tests/php/TestFeatureActivation.php
+++ b/tests/php/TestFeatureActivation.php
@@ -64,6 +64,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testNoActiveFeatures() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' );
 
 		ElasticPress\Features::factory()->setup_features();
 
@@ -81,6 +82,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testAutoActivated() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' );
 
 		ElasticPress\Features::factory()->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
@@ -110,6 +112,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testRequirementStatuses() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' ); // VIP: Since we changed to per-site option, we need to fix the failing test.
 
 		ElasticPress\Features::factory()->handle_feature_activation();
 		ElasticPress\Features::factory()->setup_features();
@@ -132,6 +135,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testAutoActivateWithSimpleFeature() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' ); // VIP: Since we changed to per-site option, we need to fix the failing test.
 
 		ElasticPress\Features::factory()->register_feature(
 			new FeatureTest()
@@ -154,6 +158,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testAutoDeactivateWithFeature() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' ); // VIP: Since we changed to per-site option, we need to fix the failing test.
 
 		ElasticPress\Features::factory()->register_feature(
 			new FeatureTest()
@@ -189,6 +194,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testAutoActivateWithFeature() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' );
 
 		ElasticPress\Features::factory()->register_feature(
 			new FeatureTest()
@@ -226,6 +232,7 @@ class TestFeatureActivation extends BaseTestCase {
 	public function testReqChangeNothingWithFeature() {
 		delete_site_option( 'ep_feature_requirement_statuses' );
 		delete_site_option( 'ep_feature_settings' );
+		delete_option( 'ep_feature_settings' ); // VIP: Since we changed to per-site option, we need to fix the failing test.
 
 		ElasticPress\Features::factory()->register_feature(
 			new FeatureTest()


### PR DESCRIPTION
## Description
Described in https://github.com/Automattic/vip-go-mu-plugins/pull/2916. We want to backfill all `ep_feature_settings` network options and transition them to subsite options.

**NOTE: THIS PR IS RELIANT ON https://github.com/Automattic/vip-go-mu-plugins/pull/2916.**

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Start up a multisite (example.com) with ES with a subsite (subsite1.example.com)
2) define `EP_IS_NETWORK` as `true` in vip-config: `define( 'EP_IS_NETWORK', true );`
3) Check out the branch for vip-go-mu-plugins @ https://github.com/Automattic/vip-go-mu-plugins/pull/2916
4) Check that `get_option( 'ep_feature_settings' );` returns false on the main site and subsite
5) Activate a feature that hasn't already been activated on the main site and is not activated on the subsite, e.g. `wp vip-search activate-feature protected_content` 
6) Check the option for both the main site and subsite `get_option( 'ep_feature_settings' );` and expect the feature to be only marked active from step 5 on the main site