### PR TITLE
adding option to replace the orderby=>ID argument

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -61,7 +61,7 @@ class Post extends Indexable {
 			'post_status'         => $this->get_indexable_post_status(),
 			'offset'              => 0,
 			'ignore_sticky_posts' => true,
-			'orderby'             => 'ID',
+			'orderby'             => $args['orderby'] ? $args['orderby'] : 'ID',
 			'order'               => 'desc',
 			'no_found_rows'       => true,
 			'ep_indexing_advanced_pagination' => true,
@@ -96,7 +96,7 @@ class Post extends Indexable {
 		if ( $args['ep_indexing_advanced_pagination'] ) {
 			$args = array_merge( $args, [
 				'suppress_filters' => false,
-				'orderby'          => 'ID',
+				'orderby'          => $args['orderby'] ? $args['orderby'] : 'ID',
 				'order'            => 'DESC',
 				'paged'            => 1,
 				'offset'           => 0,


### PR DESCRIPTION
When doing a DB count, having an orderby in the query clause can be quite expensive for large datasets, so setting its value to `none` could provide some speed benefits.

This PR will try and give the option to have a different value than `ID` for orderby parameter. 

The change proposed here is only a logical change that should keep existing functionality unchanged.

Related PR https://github.com/Automattic/vip-go-mu-plugins/pull/2921

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [x] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1. apply the patch
2. look for PR https://github.com/Automattic/vip-go-mu-plugins/pull/2921 which triggers this
3. measure time it takes to run before and after the patch against
```
wp vip-search health validate-counts
```
