### PR TITLE
Store last processed object ID during indexing in an option

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1129,9 +1129,10 @@ class Command extends WP_CLI_Command {
 				break;
 			}
 
-			// VIP: Pass in $last_processed_object_id independent of nobulk
+			// VIP: Pass in $last_processed_object_id independent of nobulk and track it in an option for long indexing processes that may get killed
 			$last_object_array_key    = array_keys( $query['objects'] )[ count( $query['objects'] ) - 1 ];
 			$last_processed_object_id = $query['objects'][ $last_object_array_key ]->ID;
+			update_option( 'vip_es_index_last_processed_id', $last_processed_object_id );
 
 			if ( ! $no_bulk ) {
 				WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $query['total_objects'], (int) $last_processed_object_id ) );


### PR DESCRIPTION
## Description
We should store the last processed object IDs in an option, especially in really long indexing operations in case they fail, so they have a point to start from.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Start indexing operation on a very large site: `wp vip-search index`
2) Stop expectedly after a few have been processed - ctrl + c
3) `wp option get vip_es_index_last_processed_id` to return the last object ID indexed