### PR TITLE
Fix get_terms_tree() infinite loop

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -373,7 +373,7 @@ function get_term_tree( $all_terms, $orderby = 'count', $order = 'desc', $flat =
 				$terms_map[ $term->term_id ] = $term;
 			}
 
-			if ( empty( $term->parent ) ) {
+			if ( empty( $term->parent ) || ! term_exists( $term->parent, $term->taxonomy ) ) {
 				$term->level = 0;
 
 				if ( empty( $orderby ) ) {


### PR DESCRIPTION
## Description
Mirrors https://github.com/10up/ElasticPress/pull/2687

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

