### PR TITLE
VIP: Update page titles for Weighting & SearchOrdering

### DIFF
--- a/includes/classes/Feature/Search/Weighting.php
+++ b/includes/classes/Feature/Search/Weighting.php
@@ -195,7 +195,7 @@ class Weighting {
 	public function add_weighting_submenu_page() {
 		add_submenu_page(
 			'elasticpress',
-			esc_html__( 'ElasticPress Search Fields & Weighting', 'elasticpress' ),
+			esc_html__( 'Search Fields & Weighting', 'elasticpress' ), // VIP: Rename page title
 			esc_html__( 'Search Fields & Weighting', 'elasticpress' ),
 			'manage_options',
 			'elasticpress-weighting',

--- a/includes/classes/Feature/SearchOrdering/SearchOrdering.php
+++ b/includes/classes/Feature/SearchOrdering/SearchOrdering.php
@@ -859,7 +859,7 @@ class SearchOrdering extends Feature {
 	 */
 	public function update_page_title( $admin_title, $title ) {
 		if ( $this->title === $title ) {
-			return __( 'ElasticPress Custom Search Results', 'elasticpress' );
+			return __( 'Custom Search Results', 'elasticpress' ); // VIP: Rename page title
 		}
 
 		return $admin_title;


### PR DESCRIPTION

## Description
Continuation of #153.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Click on "Search Fields & Weighting" menu from wp-admin and look at page title
2) Click on "Custom Search Results" menu from wp-admin and look at page title
