### PR TITLE
Add estimate to the indexing output

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1135,7 +1135,9 @@ class Command extends WP_CLI_Command {
 			$last_processed_object_id = $query['objects'][ $last_object_array_key ]->ID;
 
 			if ( ! $no_bulk ) {
-				WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), (int) ( $synced + count( $failed_objects ) ), (int) $query['total_objects'], (int) $last_processed_object_id ) );
+				$done_count = (int) ( $synced + count( $failed_objects ) );
+				$total 	    = (int) $query['total_objects'];
+				WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), $done_count, $total, (int) $last_processed_object_id ) );
 
 				$loop_counter++;
 				if ( ( $loop_counter % 10 ) === 0 ) {
@@ -1150,6 +1152,11 @@ class Command extends WP_CLI_Command {
 					$current_memory = round( memory_get_usage() / 1024 / 1024, 2 ) . 'mb';
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
+
+					$remaining     = $total - $done_count;
+					$estimate_time = round( ( $remaining / $done_count ) * $time_elapsed);
+					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Estimate: ', 'elasticpress' ) . '%N' . $this->seconds_to_hr( $estimate_time ) ) );
+
 					remove_filter( 'number_format_i18n', [ __CLASS__, 'skip_number_format_i18n' ] );
 				}
 			}

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1136,7 +1136,7 @@ class Command extends WP_CLI_Command {
 
 			if ( ! $no_bulk ) {
 				$done_count = (int) ( $synced + count( $failed_objects ) );
-				$total 	    = (int) $query['total_objects'];
+				$total      = (int) $query['total_objects'];
 				WP_CLI::log( sprintf( esc_html__( 'Processed %1$d/%2$d. Last Object ID: %3$d', 'elasticpress' ), $done_count, $total, (int) $last_processed_object_id ) );
 
 				$loop_counter++;
@@ -1147,14 +1147,14 @@ class Command extends WP_CLI_Command {
 
 					$time_elapsed_diff = $time_elapsed > 0 ? ' (+' . (string) round( $time_elapsed_calc - $time_elapsed, 2 ) . 's)' : '';
 					$time_elapsed      = timer_stop( 0, 2 );
-					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . $this->seconds_to_hr( $time_elapsed ) . $time_elapsed_diff  ) );
+					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Time elapsed: ', 'elasticpress' ) . '%N' . $this->seconds_to_hr( $time_elapsed ) . $time_elapsed_diff ) );
 
 					$current_memory = round( memory_get_usage() / 1024 / 1024, 2 ) . 'mb';
 					$peak_memory    = ' (Peak: ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'mb)';
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Memory Usage: ', 'elasticpress' ) . '%N' . $current_memory . $peak_memory ) );
 
 					$remaining     = $total - $done_count;
-					$estimate_time = round( ( $remaining / $done_count ) * $time_elapsed);
+					$estimate_time = round( ( $remaining / $done_count ) * $time_elapsed );
 					WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Estimate: ', 'elasticpress' ) . '%N' . $this->seconds_to_hr( $estimate_time ) ) );
 
 					remove_filter( 'number_format_i18n', [ __CLASS__, 'skip_number_format_i18n' ] );
@@ -1795,7 +1795,7 @@ class Command extends WP_CLI_Command {
 	/**
 	 * Convert seconds to hh:mm:ss format
 	 *
-	 * @param int $seconds
+	 * @param int $seconds seconds count
 	 * @return string
 	 */
 	private function seconds_to_hr( $seconds ) {


### PR DESCRIPTION
## Description
Are you tired of manually guestimating the remaining time for an index?! Worry no more:)

This change adds an Estimate line:
```
Processed 3/4. Last Object ID: 12
Time elapsed: 00:00:14 (+1.02s)
Memory Usage: 56.29mb (Peak: 56.66mb)
Estimate: 00:00:05
```

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test

1) Add sleep(1); to this loop - https://github.com/Automattic/ElasticPress/blob/df2b317760a855031085b2b39f3d6b6a1d52e56b/includes/classes/Command.php#L998
2) Run `wp vip-search index --per-page=1`