### PR TITLE
refactor meta key allowed check

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -744,8 +744,8 @@ class Post extends Indexable {
 	/**
 	 * Chekcs if meta key is allowed
 	 *
-	 * @param string   $meta_key
-	 * @param WP_Post  $post Post object
+	 * @param string  $meta_key meta key to check
+	 * @param WP_Post $post Post object
 	 * @since 3.6.6
 	 * @return boolean
 	 */
@@ -762,8 +762,8 @@ class Post extends Indexable {
 	/**
 	 * Filter post meta to only the allowed ones to be send to ES
 	 *
-	 * @param array    $metas Key => value pairs of post meta
-	 * @param WP_Post  $post Post object
+	 * @param array   $metas Key => value pairs of post meta
+	 * @param WP_Post $post Post object
 	 * @since 3.6.6
 	 * @return array
 	 */

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -764,7 +764,7 @@ class Post extends Indexable {
 	 *
 	 * @param array   $metas Key => value pairs of post meta
 	 * @param WP_Post $post Post object
-	 * @since 3.6.6
+	 * @since 4.3.0
 	 * @return array
 	 */
 	public function filter_allowed_metas( $metas, $post ) {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -742,6 +742,88 @@ class Post extends Indexable {
 	}
 
 	/**
+	 * Chekcs if meta key is allowed
+	 *
+	 * @param string $meta key
+	 * @param WP_Post $post Post object
+	 * @since 3.6.6
+	 * @return boolean
+	 */
+	public function is_meta_allowed( $meta_key, $post ) {
+		$test_metas = [
+			$meta_key => true
+		];
+		$filtered_test_metas = $this->filter_allowed_metas( $test_metas, $post );
+
+		return array_key_exists( $meta_key, $filtered_test_metas );
+	}
+
+	/**
+	 * Filter post meta to only the allowed ones to be send to ES
+	 *
+	 * @param array $metas Key => value pairs of post meta
+	 * @param WP_Post $post Post object
+	 * @since 3.6.6
+	 * @return array
+	 */
+	public function filter_allowed_metas( $metas, $post ) {
+		$filtered_metas = [];
+
+		/**
+		 * Filter indexable protected meta keys for posts
+		 *
+		 * @hook ep_prepare_meta_allowed_protected_keys
+		 * @param  {array} $keys Allowed protected keys
+		 * @param  {WP_Post} $post Post object
+		 * @since  1.7
+		 * @return  {array} New keys
+		 */
+		$allowed_protected_keys = apply_filters( 'ep_prepare_meta_allowed_protected_keys', [], $post );
+
+		/**
+		 * Filter public keys to exclude from indexed post
+		 *
+		 * @hook ep_prepare_meta_excluded_public_keys
+		 * @param  {array} $keys Excluded protected keys
+		 * @param  {WP_Post} $post Post object
+		 * @since  1.7
+		 * @return  {array} New keys
+		 */
+		$excluded_public_keys = apply_filters( 'ep_prepare_meta_excluded_public_keys', [], $post );
+
+		foreach ( $metas as $key => $value ) {
+
+			$allow_index = false;
+
+			if ( is_protected_meta( $key ) ) {
+
+				if ( true === $allowed_protected_keys || in_array( $key, $allowed_protected_keys, true ) ) {
+					$allow_index = true;
+				}
+			} else {
+
+				if ( true !== $excluded_public_keys && ! in_array( $key, $excluded_public_keys, true ) ) {
+					$allow_index = true;
+				}
+			}
+
+			/**
+			 * Filter force whitelisting a meta key
+			 *
+			 * @hook ep_prepare_meta_whitelist_key
+			 * @param  {bool} $whitelist True to whitelist key
+			 * @param  {string} $key Meta key
+			 * @param  {WP_Post} $post Post object
+			 * @return  {bool} New whitelist value
+			 */
+			if ( true === $allow_index || apply_filters( 'ep_prepare_meta_whitelist_key', false, $key, $post ) ) {
+				$filtered_metas[ $key ] = $value;
+			}
+		}
+		return $filtered_metas;
+	}
+
+	/**
 	 * Prepare post meta to send to ES
 	 *
 	 * @param WP_Post $post Post object
@@ -772,58 +854,11 @@ class Post extends Indexable {
 			return apply_filters( 'ep_prepared_post_meta', [], $post );
 		}
 
+		$filtered_metas = $this->filter_allowed_metas( $meta, $post );
 		$prepared_meta = [];
 
-		/**
-		 * Filter indexable protected meta keys for posts
-		 *
-		 * @hook ep_prepare_meta_allowed_protected_keys
-		 * @param  {array} $keys Allowed protected keys
-		 * @param  {WP_Post} $post Post object
-		 * @since  1.7
-		 * @return  {array} New keys
-		 */
-		$allowed_protected_keys = apply_filters( 'ep_prepare_meta_allowed_protected_keys', [], $post );
-
-		/**
-		 * Filter public keys to exclude from indexed post
-		 *
-		 * @hook ep_prepare_meta_excluded_public_keys
-		 * @param  {array} $keys Excluded protected keys
-		 * @param  {WP_Post} $post Post object
-		 * @since  1.7
-		 * @return  {array} New keys
-		 */
-		$excluded_public_keys = apply_filters( 'ep_prepare_meta_excluded_public_keys', [], $post );
-
-		foreach ( $meta as $key => $value ) {
-
-			$allow_index = false;
-
-			if ( is_protected_meta( $key ) ) {
-
-				if ( true === $allowed_protected_keys || in_array( $key, $allowed_protected_keys, true ) ) {
-					$allow_index = true;
-				}
-			} else {
-
-				if ( true !== $excluded_public_keys && ! in_array( $key, $excluded_public_keys, true ) ) {
-					$allow_index = true;
-				}
-			}
-
-			/**
-			 * Filter force whitelisting a meta key
-			 *
-			 * @hook ep_prepare_meta_whitelist_key
-			 * @param  {bool} $whitelist True to whitelist key
-			 * @param  {string} $key Meta key
-			 * @param  {WP_Post} $post Post object
-			 * @return  {bool} New whitelist value
-			 */
-			if ( true === $allow_index || apply_filters( 'ep_prepare_meta_whitelist_key', false, $key, $post ) ) {
-				$prepared_meta[ $key ] = maybe_unserialize( $value );
-			}
+		foreach ( $filtered_metas as $key => $value ) {
+			$prepared_meta[ $key ] = maybe_unserialize( $value );
 		}
 
 		/**

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -746,7 +746,7 @@ class Post extends Indexable {
 	 *
 	 * @param string  $meta_key meta key to check
 	 * @param WP_Post $post Post object
-	 * @since 3.6.6
+	 * @since 4.3.0
 	 * @return boolean
 	 */
 	public function is_meta_allowed( $meta_key, $post ) {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -742,7 +742,7 @@ class Post extends Indexable {
 	}
 
 	/**
-	 * Chekcs if meta key is allowed
+	 * Checks if meta key is allowed
 	 *
 	 * @param string  $meta_key meta key to check
 	 * @param WP_Post $post Post object

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -744,15 +744,16 @@ class Post extends Indexable {
 	/**
 	 * Chekcs if meta key is allowed
 	 *
-	 * @param string $meta key
-	 * @param WP_Post $post Post object
+	 * @param string   $meta_key
+	 * @param WP_Post  $post Post object
 	 * @since 3.6.6
 	 * @return boolean
 	 */
 	public function is_meta_allowed( $meta_key, $post ) {
 		$test_metas = [
-			$meta_key => true
+			$meta_key => true,
 		];
+
 		$filtered_test_metas = $this->filter_allowed_metas( $test_metas, $post );
 
 		return array_key_exists( $meta_key, $filtered_test_metas );
@@ -761,8 +762,8 @@ class Post extends Indexable {
 	/**
 	 * Filter post meta to only the allowed ones to be send to ES
 	 *
-	 * @param array $metas Key => value pairs of post meta
-	 * @param WP_Post $post Post object
+	 * @param array    $metas Key => value pairs of post meta
+	 * @param WP_Post  $post Post object
 	 * @since 3.6.6
 	 * @return array
 	 */

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -136,6 +136,7 @@ class SyncManager extends SyncManagerAbstract {
 		if ( in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			$indexable_post_types = $indexable->get_indexable_post_types();
 
+
 			if ( in_array( $post_type, $indexable_post_types, true ) ) {
 				/**
 				 * Filter to kill post sync

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -128,8 +128,8 @@ class SyncManager extends SyncManagerAbstract {
 			return;
 		}
 
-		$allowed_meta_to_be_indexed = $indexable->prepare_meta( $post );
-		if ( ! in_array( $meta_key, array_keys( $allowed_meta_to_be_indexed ), true ) ) {
+		$is_meta_allowed = $indexable->is_meta_allowed( $meta_key, $post );
+		if ( ! $is_meta_allowed ) {
 			return;
 		}
 

--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -136,7 +136,6 @@ class SyncManager extends SyncManagerAbstract {
 		if ( in_array( $post->post_status, $indexable_post_statuses, true ) ) {
 			$indexable_post_types = $indexable->get_indexable_post_types();
 
-
 			if ( in_array( $post_type, $indexable_post_types, true ) ) {
 				/**
 				 * Filter to kill post sync

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -6784,4 +6784,33 @@ class TestPost extends BaseTestCase {
 		$this->assertArrayHasKey( 'terms.category.term_id', $args['post_filter']['bool']['must'][0]['bool']['must'][0]['terms'] );
 		$this->assertContains( $cat, $args['post_filter']['bool']['must'][0]['bool']['must'][0]['terms']['terms.category.term_id'] );
 	}
+
+
+	/**
+	 * Tests is_meta_allowed
+	 *
+	 * @return void
+	 * @group  is_meta_allowed
+	 */
+	public function testIsMetaAllowed() {
+		$meta_not_protected 		 = 'meta';
+		$meta_not_protected_excluded = 'meta_excluded';
+		$meta_protected 		 	 = '_meta';
+		$meta_protected_allowed 	 = '_meta_allowed';
+
+		add_filter( 'ep_prepare_meta_allowed_protected_keys', function () use ( $meta_protected_allowed ) {
+			return [ $meta_protected_allowed ];
+		} );
+		add_filter( 'ep_prepare_meta_excluded_public_keys', function () use ( $meta_not_protected_excluded ) {
+			return [ $meta_not_protected_excluded ];
+		} );
+
+		$indexable = \ElasticPress\Indexables::factory()->get( 'post' );
+
+		$this->assertTrue( $indexable->is_meta_allowed( $meta_not_protected, null ) );
+		$this->assertTrue( $indexable->is_meta_allowed( $meta_protected_allowed, null ) );
+
+		$this->assertFalse( $indexable->is_meta_allowed( $meta_not_protected_excluded, null ) );
+		$this->assertFalse( $indexable->is_meta_allowed( $meta_protected, null ) );
+	}
 }


### PR DESCRIPTION

## Description

When meta key is deleted from a post, this does NOT trigger reindex of that post due to the way of allowed metas are detected.

This change makes it so that we have the logic that evaluates if given meta_key is allowed separate from the logic that prepares metas for indexing. That way we can trigger even for meta key that is not being prepared to indexed (because it was just deleted) but is allowed to be in index (was in the indexed document before).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test

1) Add this filter impl:
```
add_filter( 'vip_search_post_meta_allow_list', function ( $allow, $post = null ) {
	$allow['testing'] = true;
	return $allow;
}, 10, 2 );
```
2) Add meta - `vip dev-env exec --  wp post meta set 1 testing foobar`
3) Check the document in ES - `vip dev-env exec --  wp vip-search documents get post 1 --format=json | jq '.[0].meta'`
4) Remove meta `vip dev-env exec --  wp  post meta delete 1 testing`
5) Check the document in ES - `vip dev-env exec --  wp vip-search documents get post 1 --format=json | jq '.[0].meta'`

