### PR TITLE
Add _doing_it_wrong() when attempt to query window size is too large

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -360,6 +360,11 @@ abstract class Indexable {
 			$result_window     = $formatted_args['from'] + $formatted_args['size'];
 			$max_result_window = apply_filters( 'ep_max_result_window', 10000 );
 			if ( $result_window > $max_result_window ) {
+				_doing_it_wrong(
+					self::class . '::' . __FUNCTION__, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					esc_html( "Search: Attempting to query {$result_window} results, which is more than the maximum of {$max_result_window}. As a result, query has not been offloaded to Elasticsearch." ),
+					null
+				);
 				return false;
 			}
 		}


### PR DESCRIPTION
## Description
We have a hard limit of 10000, so anything over 10000 will not be offloaded to ES. We should add a `_doing_it_wrong` so the notice will display to the user on attempt to query over 10000.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Add the below snippet to `functions.php`:
```
add_action( 'init', function() {
	$args = [
		's' => 'hello',
		'posts_per_page' => '10001',
		'es' => true,
	];
	$query = new WP_Query( $args );
});
```
2) Notice in Search Dev Tools, there are no ES queries
3) Go to Query monitor and see the below notice being thrown:
```
Function ElasticPress\Indexable::query_es was called incorrectly. Search: Attempting to query 10001, which is more than 10000! Please see Debugging in WordPress for more information.
```
