### PR TITLE
Use ep_last_cli_index option on a per-site basis

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -884,11 +884,8 @@ class Command extends WP_CLI_Command {
 			'errors'       => $index_errors,
 		);
 
-		if ( defined( 'EP_IS_NETWORK' ) && EP_IS_NETWORK ) {
-			update_site_option( 'ep_last_cli_index', $index_results );
-		} else {
-			update_option( 'ep_last_cli_index', $index_results, false );
-		}
+		// VIP: Use option on a per-site basis rather than network
+		update_option( 'ep_last_cli_index', $index_results, false );
 
 		/**
 		 * Fires after executing a CLI index
@@ -1533,11 +1530,11 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI args.
 	 */
 	public function get_last_cli_index( $args, $assoc_args ) {
-
-		$last_sync = get_site_option( 'ep_last_cli_index', array() );
+		// VIP: Use option on a per-site basis rather than network
+		$last_sync = get_option( 'ep_last_cli_index', array() );
 
 		if ( isset( $assoc_args['clear'] ) ) {
-			delete_site_option( 'ep_last_cli_index' );
+			delete_option( 'ep_last_cli_index' );
 		}
 
 		WP_CLI::line( wp_json_encode( $last_sync ) );


### PR DESCRIPTION
## Description
On a multisite without the `EP_IS_NETWORK` constant defined, running `wp vip-search get-last-cli-index` will always return empty because it's being stored on an individual site option but checking against the network option. 
 
## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Create a multi-site and do not define `EP_IS_NETWORK`
2) Run an index `wp vip-search index`
3) Run `wp vip-search get-last-cli-index` and notice it returning `[]`