### PR TITLE
fallback to empty array if no _source in hit

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -402,7 +402,7 @@ class Elasticsearch {
 			$documents = [];
 
 			foreach ( $hits as $hit ) {
-				$document            = $hit['_source'];
+				$document            = isset( $hit['_source'] ) ? $hit['_source'] : array();
 				$document['site_id'] = $this->parse_site_id( $hit['_index'] );
 
 				if ( ! empty( $hit['highlight'] ) ) {


### PR DESCRIPTION
## Description

Adding a null check to `$hit[_source]` for instances when source is not returned.

This scenario happens for instance in our count [validation logic](https://github.com/Automattic/vip-go-mu-plugins-built/blob/38365e08c9612e5ec4e3d2c483f1a6d9d191117b/search/includes/classes/class-health.php#L173). We by design suppress `_source` which includes documents' content to limit the amount of data needed to transfer as we are only interested in count in that specific scenario.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.


Upstream PR - https://github.com/10up/ElasticPress/pull/2992

## Steps to Test


1) `vip dev-env exec -- wp vip-search health validate-counts`
2) No warnings



