### PR TITLE
Pull in https://github.com/10up/ElasticPress/pull/2670

### DIFF
--- a/includes/classes/Indexable/User/User.php
+++ b/includes/classes/Indexable/User/User.php
@@ -129,7 +129,25 @@ class User extends Indexable {
 		 * Support `role` query arg
 		 */
 		if ( ! empty( $blog_id ) ) {
-			if ( ! empty( $query_vars['role'] ) ) {
+			// If a blog id is set, we will apply at least one filter for roles.
+			$use_filters = true;
+
+			// If there are no specific roles named, make sure the user is a member of the site.
+			if ( empty( $query_vars['role'] ) && empty( $query_vars['role__in'] ) && empty( $query_vars['role__not_in'] ) ) {
+				$filter['bool']['must'][]     = array(
+					'exists' => array(
+						'field' => 'capabilities.' . $blog_id . '.roles',
+					),
+				);
+				/**
+				 * EP versions prior to 4.1.0 set non-existent roles as `0`.
+				 */
+				$filter['bool']['must_not'][] = array(
+					'term' => array(
+						'capabilities.' . $blog_id . '.roles' => 0,
+					),
+				);
+			} elseif ( ! empty( $query_vars['role'] ) ) {
 				$roles = (array) $query_vars['role'];
 
 				foreach ( $roles as $role ) {
@@ -141,8 +159,6 @@ class User extends Indexable {
 						),
 					);
 				}
-
-				$use_filters = true;
 			} else {
 				if ( ! empty( $query_vars['role__in'] ) ) {
 					$roles_in = (array) $query_vars['role__in'];
@@ -170,8 +186,6 @@ class User extends Indexable {
 							),
 						);
 					}
-
-					$use_filters = true;
 				}
 			}
 		}
@@ -206,8 +220,6 @@ class User extends Indexable {
 
 		if ( ! empty( $meta_queries ) ) {
 			$filter['bool']['must'][] = $this->build_meta_query( $meta_queries );
-
-			$use_filters = true;
 		}
 
 		/**
@@ -735,7 +747,7 @@ class User extends Indexable {
 		 * WP_User_Query doesn't let us get users across all blogs easily. This is the best
 		 * way to do that.
 		 */
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared  
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$objects = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS ID FROM {$wpdb->users} {$orderby} LIMIT %d, %d", (int) $args['offset'], (int) $args['number'] ) );
 
 		return [
@@ -888,7 +900,7 @@ class User extends Indexable {
 
 			if ( ! empty( $roles ) ) {
 				$prepared_roles[ (int) $site['blog_id'] ] = [
-					'roles' => array_keys( $roles ),
+					'roles' => array_keys( (array) $roles ),
 				];
 			}
 		}


### PR DESCRIPTION
## Description
This pulls in changes from https://github.com/10up/ElasticPress/pull/2670, where users should only be showing up for the blogs they are assigned to.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
1) Create user on `network/users.php` but do not add it to any blogs yet
2) Go to site ID 1 dashboard and search for user in `wp-admin/users.php`
3) you will see results appear when it shouldn't
4) Apply PR and refresh from step 2