### PR TITLE
Fix saved synonyms disappearing after re-index

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -253,10 +253,11 @@ class Synonyms {
 					'post_type'      => self::POST_TYPE_NAME,
 					'posts_per_page' => 1,
 					'orderby'        => 'modified',
+					'post_status'    => 'any',
 				)
 			);
 
-			$this->synonym_post_id = 1 === $query_synonym_post->post_count ? $query_synonym_post->posts[0] : false;
+			$this->synonym_post_id = ( $query_synonym_post->post_count >= 1 ) ? $query_synonym_post->posts[0] : false;
 
 			if ( ! $this->synonym_post_id ) {
 				$this->synonym_post_id = $this->insert_default_synonym_post();


### PR DESCRIPTION
## Description
Pulls in https://github.com/10up/ElasticPress/pull/2517 which fixes synonyms being lost after re-indexing by using the correct WP_Query to look for them (since they were being saved as drafts).

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.
