### PR TITLE
Use ep_fuzziness_arg over ep_match_fuzziness

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -1440,7 +1440,7 @@ class Post extends Indexable {
 								 * @param {array} $query_vars Query variables
 								 * @return  {string} New boost
 								 */
-								'fuzziness' => apply_filters( 'ep_match_fuzziness', 'auto', $search_fields, $args ),
+								'fuzziness' => apply_filters( 'ep_fuzziness_arg', 'auto', $search_fields, $args ), // VIP: Use old filter name
 								'operator'  => 'and',
 							),
 						),


### PR DESCRIPTION
## Description
It doesn't make sense to introduce a new filter in the new algorithm. It makes it harder for those wanting to quickly "migrate" to the new algorithm and keep similar settings. We should keep it to `ep_fuzziness_arg`, especially since that's what customers are using in their codebase.