### PR TITLE
Fix wp vip-search status CLI on single sites

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -442,7 +442,7 @@ class Command extends WP_CLI_Command {
 	 * @return array
 	 */
 	protected function get_index_names() {
-		$sites = ( is_multisite() ) ? Utils\get_sites() : array( 'blog_id' => get_current_blog_id() );
+		$sites = ( is_multisite() ) ? Utils\get_sites() : array( array( 'blog_id' => get_current_blog_id() ) );
 
 		$all_indexables = Indexables::factory()->get_all();
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -109,7 +109,8 @@ function get_index_prefix() {
  * @return bool
  */
 function is_epio() {
-	return filter_var( preg_match( '#elasticpress\.io#i', get_host() ), FILTER_VALIDATE_BOOLEAN );
+	// VIP: We're on VIP, so return false immediately.
+	return false;
 }
 
 /**


### PR DESCRIPTION
## Description
It's timing out in the `is_epio()` check, so let's bail. Also, for single sites, it's not assigning the correct default array structure for `wp vip-search status`.