### PR TITLE
Add back backtrace for Search Dev Tools

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1624,6 +1624,7 @@ class Elasticsearch {
 	 */
 	protected function add_query_log( $query ) {
 		if ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ( defined( 'WP_EP_DEBUG' ) && WP_EP_DEBUG ) ) {
+			$query['backtrace'] = wp_debug_backtrace_summary( null, 1, false ); // VIP: Search Dev Tools relies on this backtrace
 			$this->queries[] = $query;
 		}
 


### PR DESCRIPTION
## Description
The [4.2.2 BFM removed the backtrace](https://github.com/Automattic/ElasticPress/pull/175) which borked the Trace functionality in Search Dev Tools. Let's add it back.
