### PR TITLE
Fix warning 'Undefined array key "server_type"'

### DIFF
--- a/includes/classes/Elasticsearch.php
+++ b/includes/classes/Elasticsearch.php
@@ -1340,7 +1340,7 @@ class Elasticsearch {
 			if ( ! empty( $es_info ) ) {
 				$this->elasticsearch_version = $es_info['version'];
 				$this->elasticsearch_plugins = $es_info['plugins'];
-				$this->server_type           = $es_info['server_type'];
+				$this->server_type           = $es_info['server_type'] ?? 'elasticsearch'; // VIP: Hardcode if array key isn't found from older version EP transients.
 				return;
 			}
 		}


### PR DESCRIPTION
## Description
Going from an older version of EP to the latest one, the `server_type` array key is introduced. Let's hardcode if it the transient is stale.