### PR TITLE
get_indexing_status() should only account for CLI indexing

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -492,7 +492,7 @@ function get_indexing_status() {
 		// Change method name for retrocompatibility.
 		// `dashboard` is used mainly because hooks names depend on that.
 		if ( ! empty( $index_status['method'] ) && 'dashboard' === $index_status['method'] ) {
-			$index_status['method'] = 'web';
+			$index_status['method'] = 'cli'; // VIP: We only use CLI.
 		}
 
 		if ( ! empty( $index_status['method'] ) && 'web' === $index_status['method'] ) {


### PR DESCRIPTION
## Description
Since it's not possible to index via web, we should change the logic to retrofit indexing done via CLI.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.
