### PR TITLE
Do not autoload ep_index_meta option

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -969,7 +969,7 @@ class IndexHelper {
 	 */
 	protected function output( $message_text, $type = 'info', $context = '' ) {
 		if ( $this->index_meta ) {
-			Utils\update_option( 'ep_index_meta', $this->index_meta );
+			Utils\update_option( 'ep_index_meta', $this->index_meta, false ); // VIP: Do not autoload ep_index_meta option to avoid alloption issues.
 		} else {
 			Utils\delete_option( 'ep_index_meta' );
 			$totals = $this->get_last_index();


### PR DESCRIPTION
## Description
Do not autoload ep_index_meta option

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.
