### PR TITLE
Add VIP specific hooks to the Post\SyncManager::tear_down

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -93,6 +93,12 @@ class SyncManager extends SyncManagerAbstract {
 		remove_action( 'wp_initialize_site', array( $this, 'action_create_blog_index' ) );
 		remove_filter( 'ep_sync_insert_permissions_bypass', array( $this, 'filter_bypass_permission_checks_for_machines' ) );
 		remove_filter( 'ep_sync_delete_permissions_bypass', array( $this, 'filter_bypass_permission_checks_for_machines' ) );
+
+		// VIP: VIP-specific things
+		remove_action( 'wp_update_comment_count', array( $this, 'action_sync_on_update' ), 999, 3 );
+		remove_action( 'edited_term', array( $this, 'action_edited_term' ), 10, 3 );
+		remove_action( 'set_object_terms', array( $this, 'action_set_object_terms' ), 10, 6 );
+		// End VIP
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

This removes VIP-specific hooks in Post\SyncManager::tear_down.


### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
