### PR TITLE
Add kill_sync() to action_edited_term

### DIFF
--- a/includes/classes/Indexable/Post/SyncManager.php
+++ b/includes/classes/Indexable/Post/SyncManager.php
@@ -460,6 +460,10 @@ class SyncManager extends SyncManagerAbstract {
 	public function action_edited_term( $term_id, $tt_id, $taxonomy ) {
 		global $wpdb;
 
+		if ( $this->kill_sync() ) {
+			return;
+		}
+
 		/**
 		 * Filter to whether skip a sync during autosave, defaults to true
 		 *


### PR DESCRIPTION
## Checklist
Adds the missing killswitch
