### PR TITLE
CANTINA-948: Add inheritable properties to Indexable so they aren't considered dynamic

### DIFF
--- a/includes/classes/Feature/Facets/Block.php
+++ b/includes/classes/Feature/Facets/Block.php
@@ -19,6 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Block {
 	/**
+	 * The renderer instance.
+	 *
+	 * @var Renderer
+	 */
+	public $renderer;
+
+	/**
 	 * Hook block funcionality.
 	 */
 	public function setup() {

--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -64,6 +64,22 @@ abstract class Indexable {
 	public $support_indexing_advanced_pagination = false;
 
 	/**
+	 * Indexable slug
+	 *
+	 * @since 4.5.0
+	 * @var string
+	 */
+	public $slug = '';
+
+	/**
+	 * Indexable labels
+	 *
+	 * @since 4.5.0
+	 * @var array
+	 */
+	public $labels = [];
+
+	/**
 	 * Get number of bulk items to index per page
 	 *
 	 * @since  3.0


### PR DESCRIPTION
## Description
Finish the remaining CANTINA-948 tasks for PHP 8.2

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
