### PR TITLE
Fix: Fatal error undefined method ElasticPress\IndexHelper::process_error_limit()

### DIFF
--- a/includes/classes/IndexHelper.php
+++ b/includes/classes/IndexHelper.php
@@ -691,7 +691,7 @@ class IndexHelper {
 
 				$wp_error_messages = $return->get_error_messages();
 
-				$this->process_error_limit(
+				$this->maybe_process_error_limit(
 					count( $this->index_meta['current_sync_item']['errors'] ) + count( $wp_error_messages ),
 					count( $this->index_meta['current_sync_item']['errors'] ),
 					$wp_error_messages


### PR DESCRIPTION
## Description
Pulls in https://github.com/10up/ElasticPress/pull/3454

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
