### PR TITLE
PHP Fix: PHP Deprecated: json_encode(): Passing null to parameter #2

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1562,7 +1562,7 @@ class Command extends WP_CLI_Command {
 	 * @param boolean $pretty_print_flag Whether it should or not be formatted.
 	 */
 	protected function pretty_json_encode( $json_obj, $pretty_print_flag ) {
-		$flag = $pretty_print_flag ? JSON_PRETTY_PRINT : null;
+		$flag = $pretty_print_flag ? JSON_PRETTY_PRINT : 0;
 		WP_CLI::line( wp_json_encode( $json_obj, $flag ) );
 	}
 }


### PR DESCRIPTION
## Description
Pulls in https://github.com/10up/ElasticPress/pull/3532

## Checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
