### PR TITLE
Add skip_query_integration from upstream commit

### DIFF
--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7515,4 +7515,38 @@ class TestPost extends BaseTestCase {
 		$this->assertTrue( $query->elasticsearch_success );
 	}
 
+	/**
+	 * Test that query with unsupported orderby does not use EP.
+	 *
+	 * @since 4.5.0
+	 */
+	public function testQueryWithUnSupportedOrderByDoesNotUseEP() {
+		// test for post__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull( $query->elasticsearch_success  );
+
+		// test for post_name__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post_name__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull( $query->elasticsearch_success  );
+
+		// test for post_parent__in
+		$query = new \WP_Query( array(
+			'orderby' => 'post_parent__in',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull(  $query->elasticsearch_success  );
+
+		// test for parent
+		$query = new \WP_Query( array(
+			'orderby' => 'parent',
+			'ep_integrate' => true,
+		) );
+		$this->assertNull(  $query->elasticsearch_success  );
+	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7522,29 +7522,30 @@ class TestPost extends BaseTestCase {
 	 */
 	public function testQueryWithUnSupportedOrderByDoesNotUseEP() {
 		// test for post__in
-		$query = new \WP_Query( array(
-			'orderby' => 'post__in',
+		$query = new \WP_Query(
+			array(
+			'orderby'      => 'post__in',
 			'ep_integrate' => true,
 		) );
 		$this->assertNull( $query->elasticsearch_success  );
 
 		// test for post_name__in
 		$query = new \WP_Query( array(
-			'orderby' => 'post_name__in',
+			'orderby'      => 'post_name__in',
 			'ep_integrate' => true,
 		) );
 		$this->assertNull( $query->elasticsearch_success  );
 
 		// test for post_parent__in
 		$query = new \WP_Query( array(
-			'orderby' => 'post_parent__in',
+			'orderby'      => 'post_parent__in',
 			'ep_integrate' => true,
 		) );
 		$this->assertNull(  $query->elasticsearch_success  );
 
 		// test for parent
 		$query = new \WP_Query( array(
-			'orderby' => 'parent',
+			'orderby'      => 'parent',
 			'ep_integrate' => true,
 		) );
 		$this->assertNull(  $query->elasticsearch_success  );

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7524,30 +7524,36 @@ class TestPost extends BaseTestCase {
 		// test for post__in
 		$query = new \WP_Query(
 			array(
-			'orderby'      => 'post__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull( $query->elasticsearch_success  );
+				'orderby'      => 'post__in',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for post_name__in
-		$query = new \WP_Query( array(
-			'orderby'      => 'post_name__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull( $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post_name__in',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for post_parent__in
-		$query = new \WP_Query( array(
-			'orderby'      => 'post_parent__in',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull(  $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'post_parent__in',
+				'ep_integrate' => true,
+			) );
+		$this->assertNull( $query->elasticsearch_success );
 
 		// test for parent
-		$query = new \WP_Query( array(
-			'orderby'      => 'parent',
-			'ep_integrate' => true,
-		) );
-		$this->assertNull(  $query->elasticsearch_success  );
+		$query = new \WP_Query(
+			array(
+				'orderby'      => 'parent',
+				'ep_integrate' => true,
+			)
+		);
+		$this->assertNull( $query->elasticsearch_success );
 	}
 }

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -7544,7 +7544,8 @@ class TestPost extends BaseTestCase {
 			array(
 				'orderby'      => 'post_parent__in',
 				'ep_integrate' => true,
-			) );
+			)
+		);
 		$this->assertNull( $query->elasticsearch_success );
 
 		// test for parent


### PR DESCRIPTION
## Description
Pulls in https://github.com/10up/ElasticPress/pull/3273

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
