### PR TITLE
Set has_password default value to null for query_db

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -74,7 +74,7 @@ class Post extends Indexable {
 			'order'                           => 'desc',
 			'no_found_rows'                   => false,
 			'ep_indexing_advanced_pagination' => true,
-			'has_password'                    => true,
+			'has_password'                    => null,
 		];
 
 		if ( isset( $args['per_page'] ) ) {

--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -74,7 +74,7 @@ class Post extends Indexable {
 			'order'                           => 'desc',
 			'no_found_rows'                   => false,
 			'ep_indexing_advanced_pagination' => true,
-			'has_password'                    => false,
+			'has_password'                    => true,
 		];
 
 		if ( isset( $args['per_page'] ) ) {

--- a/tests/php/indexables/TestPost.php
+++ b/tests/php/indexables/TestPost.php
@@ -5804,22 +5804,22 @@ class TestPost extends BaseTestCase {
 		);
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
-		$this->assertEquals( $post_id_3, $post_ids[0] );
+		$this->assertEquals( $post_id_4, $post_ids[0] );
 		$this->assertCount( 1, $results['objects'] );
-		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		// Second loop.
 		$results = $indexable_post_object->query_db(
 			[
 				'per_page'                             => 1,
-				'ep_indexing_last_processed_object_id' => $post_id_3,
+				'ep_indexing_last_processed_object_id' => $post_id_4,
 			]
 		);
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
-		$this->assertEquals( $post_id_2, $post_ids[0] );
+		$this->assertEquals( $post_id_3, $post_ids[0] );
 		$this->assertCount( 1, $results['objects'] );
-		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		// A custom upper_limit_object_id was passed in.
 		$results = $indexable_post_object->query_db(
@@ -5869,13 +5869,13 @@ class TestPost extends BaseTestCase {
 		);
 
 		$post_ids = wp_list_pluck( $results['objects'], 'ID' );
-		$this->assertEquals( $post_id_2, $post_ids[0] );
-		$this->assertCount( 2, $results['objects'] );
-		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertEquals( $post_id_3, $post_ids[0] );
+		$this->assertCount( 3, $results['objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		$results = $indexable_post_object->query_db(
 			[
-				'offset' => 3,
+				'offset' => 4,
 			]
 		);
 
@@ -5888,8 +5888,8 @@ class TestPost extends BaseTestCase {
 			]
 		);
 
-		$this->assertCount( 3, $results['objects'] );
-		$this->assertEquals( 3, $results['total_objects'] );
+		$this->assertCount( 4, $results['objects'] );
+		$this->assertEquals( 4, $results['total_objects'] );
 
 		// Test the first loop of the indexing.
 		$results = $indexable_post_object->query_db(


### PR DESCRIPTION
## Description

To maintain consistent results between health validate-counts and validate-contents, this pull request (PR) updates the 'has_password' to null in the query args, in the query_db function, which is called by the validate-counts. This modification will result in all posts being retrieved by default for the validate-counts, aligning its behavior with the validate-contents.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.

