### PR TITLE
BB8-11713: Add type checking to additional date fields we index

### DIFF
--- a/includes/classes/Indexable/Post/Post.php
+++ b/includes/classes/Indexable/Post/Post.php
@@ -499,9 +499,9 @@ class Post extends Indexable {
 			'terms'                   => $this->prepare_terms( $post ),
 			'meta'                    => $this->prepare_meta_types( $this->prepare_meta( $post ) ), // post_meta removed in 2.4.
 			'date_terms'              => $this->prepare_date_terms( $post_date ),
-			'date_gmt_terms'          => $this->prepare_date_terms( $post_date_gmt ),
-			'modified_date_terms'     => $this->prepare_date_terms( $post_modified ),
-			'modified_date_gmt_terms' => $this->prepare_date_terms( $post_modified_gmt ),
+			'date_gmt_terms'          => $this->prepare_date_terms( $post_date_gmt ?? '' ), // VIP: Index additional fields
+			'modified_date_terms'     => $this->prepare_date_terms( $post_modified ?? '' ), // VIP: Index additional fields
+			'modified_date_gmt_terms' => $this->prepare_date_terms( $post_modified_gmt ?? '' ), // VIP: Index additional fields
 			'comment_count'           => $comment_count,
 			'comment_status'          => $comment_status,
 			'ping_status'             => $ping_status,


### PR DESCRIPTION
## Description
Fixes `strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated`

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
