### PR TITLE
Do not sync empty queues

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -388,6 +388,10 @@ abstract class Indexable {
 
 			$document = $this->prepare_document( $object_id );
 
+			if ( empty( $document ) ) {
+				continue;
+			}
+
 			/**
 			 * Conditionally kill indexing on a specific object
 			 *
@@ -402,6 +406,12 @@ abstract class Indexable {
 			$document_str .= "\n\n";
 
 			$documents[] = $document_str;
+		}
+
+		if ( empty( $documents ) ) {
+			return [
+				new \WP_Error( 'ep_bulk_index_no_documents', esc_html__( 'It was not possible to create a body request with the document IDs provided.', 'elasticpress' ), $object_ids ),
+			];
 		}
 
 		$results = $this->send_bulk_index_request( $documents );

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -208,7 +208,7 @@ abstract class SyncManager {
 			if ( empty( $sync_queue ) ) {
 				continue;
 			}
-			
+
 			if ( $current_blog_id !== $blog_id ) {
 				switch_to_blog( $blog_id );
 			}

--- a/includes/classes/SyncManager.php
+++ b/includes/classes/SyncManager.php
@@ -205,6 +205,10 @@ abstract class SyncManager {
 
 		$current_blog_id = get_current_blog_id();
 		foreach ( $this->sync_queue as $blog_id => $sync_queue ) {
+			if ( empty( $sync_queue ) ) {
+				continue;
+			}
+			
 			if ( $current_blog_id !== $blog_id ) {
 				switch_to_blog( $blog_id );
 			}


### PR DESCRIPTION
## Description
Pulls in https://github.com/10up/ElasticPress/pull/3770.

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
