### PR TITLE
ci: do not use deprecated `actions/cache`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,5 @@
 name: Test
 
-env:
-  COMPOSER_VERSION: "2"
-  COMPOSER_CACHE: "${{ github.workspace }}/.composer-cache"
-
 on:
   push:
     branches:
@@ -20,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Start MySQL
       run: sudo systemctl start mysql.service
@@ -37,27 +33,14 @@ jobs:
       with:
         elasticsearch version: '7.5.0'
 
-    - name: Set standard 10up cache directories
-      run: |
-        composer config -g cache-dir "${{ env.COMPOSER_CACHE }}"
-
-    - name: Prepare composer cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.COMPOSER_CACHE }}
-        key: composer-${{ env.COMPOSER_VERSION }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          composer-${{ env.COMPOSER_VERSION }}-
-
     - name: Set PHP version
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.2'
         coverage: none
-        tools: composer:v1
 
-    - name: Install dependencies
-      run: composer install
+    - name: Install PHP Dependencies
+      uses: ramsey/composer-install@3.0.0
 
     - name: Setup WP Tests
       run: |


### PR DESCRIPTION
> Starting February 1st, 2025, Actions’ cache storage will move to a new architecture, resulting in the deprecation of v1-v2 of [actions/cache](https://github.com/actions/cache). Attempting to use a version of the action after the announced deprecation date will result in a workflow failure. Please note: if you are pinned to a specific version or SHA of the action, your workflows will also fail after February 1st. We strongly encourage you to update your workflows to begin using v3 or v4 of actions/cache as soon as possible.
>
> https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/

In this PR, we are getting rid of `actions/cache@v2`.
