### PR TITLE
Tests: Update to rid deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
   >
   <coverage>
     <include>

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -254,7 +254,8 @@ class TestTerm extends BaseTestCase {
 			]
 		);
 
-		$this->assertObjectNotHasAttribute( 'elasticsearch_success', $term_query );
+		$properties = get_object_vars( $term_query );
+		$this->assertArrayNotHasKey( 'elasticsearch_success', $properties );
 
 		$this->assertEquals( 4, count( $term_query->terms ) );
 
@@ -1002,7 +1003,8 @@ class TestTerm extends BaseTestCase {
 				]
 			);
 
-			$this->assertObjectNotHasAttribute( 'elasticsearch_success', $term_query );
+			$properties = get_object_vars( $term_query );
+			$this->assertArrayNotHasKey( 'elasticsearch_success', $properties );
 
 			$wp_slugs[ $query_type ] = array_values( $term_query->terms );
 
@@ -1444,16 +1446,17 @@ class TestTerm extends BaseTestCase {
 
 		$term->remap_terms( $new_term );
 
-		$this->assertObjectHasAttribute( 'ID', $new_term );
-		$this->assertObjectHasAttribute( 'term_id', $new_term );
-		$this->assertObjectHasAttribute( 'name', $new_term );
-		$this->assertObjectHasAttribute( 'slug', $new_term );
-		$this->assertObjectHasAttribute( 'term_group', $new_term );
-		$this->assertObjectHasAttribute( 'term_taxonomy_id', $new_term );
-		$this->assertObjectHasAttribute( 'taxonomy', $new_term );
-		$this->assertObjectHasAttribute( 'description', $new_term );
-		$this->assertObjectHasAttribute( 'parent', $new_term );
-		$this->assertObjectHasAttribute( 'count', $new_term );
+		$properties = get_object_vars( $new_term );
+		$this->assertArrayHasKey( 'ID', $properties );
+		$this->assertArrayHasKey( 'term_id', $properties );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'slug', $properties );
+		$this->assertArrayHasKey( 'term_group', $properties );
+		$this->assertArrayHasKey( 'term_taxonomy_id', $properties );
+		$this->assertArrayHasKey( 'taxonomy', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'parent', $properties );
+		$this->assertArrayHasKey( 'count', $properties );
 
 		$this->assertSame( $new_term->ID, $current_term->term_id );
 		$this->assertSame( $new_term->term_id, $current_term->term_id );


### PR DESCRIPTION
## Description
Fixes following deprecations: 

```
1) ElasticPressTest\TestTerm::testBasicTermQuery
assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectNotHasProperty() instead.
2) ElasticPressTest\TestTerm::testHierarchicalTerms
assertObjectNotHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectNotHasProperty() instead.
3) ElasticPressTest\TestTerm::testRemapTerms
assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() instead.
```
```
PHPUnit 9.6.19 by Sebastian Bergmann and contributors.
  Warning - The configuration file did not pass validation!
  The following problems have been detected:
  Line 11:
  - Element 'phpunit', attribute '{https://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation': The attribute '{https://www.w3.org/2001/XMLSchema-instance}noNamespaceSchemaLocation' is not allowed.
  - 
  - ```