### PR TITLE
Ported over the maybe_change_filter_position() in Synonyms from the 10up ElasticPress codebase

### DIFF
--- a/includes/classes/Feature/Search/Synonyms.php
+++ b/includes/classes/Feature/Search/Synonyms.php
@@ -387,10 +387,12 @@ class Synonyms {
 		$mapping['settings']['analysis']['filter'][ $filter_name ] = $this->get_synonym_filter();
 
 		// Tell the analyzer to use our newly created filter.
-		$mapping['settings']['analysis']['analyzer']['default']['filter'] = array_values(
-			array_merge(
-				[ $filter_name ],
-				$mapping['settings']['analysis']['analyzer']['default']['filter']
+		$mapping['settings']['analysis']['analyzer']['default_search']['filter'] = $this->maybe_change_filter_position(
+			array_values(
+				array_merge(
+					[ $filter_name ],
+					$mapping['settings']['analysis']['analyzer']['default_search']['filter'],
+				)
 			)
 		);
 
@@ -476,11 +478,13 @@ class Synonyms {
 				$setting['index']['analysis']['filter']['ep_synonyms_filter'] = $filter;
 
 				// Add the analyzer.
-				$setting['index']['analysis']['analyzer']['default']['filter'] = array_values(
-					array_unique(
-						array_merge(
-							[ $this->get_synonym_filter_name() ],
-							$filters
+				$setting['index']['analysis']['analyzer']['default_search']['filter'] = $this->maybe_change_filter_position(
+					array_values(
+						array_unique(
+							array_merge(
+								[ $this->get_synonym_filter_name() ],
+								$filters
+							)
 						)
 					)
 				);
@@ -816,5 +820,23 @@ class Synonyms {
 			],
 			true
 		);
+	}
+
+	/**
+	 * Change the position of the lowercase filter to the beginning of the array.
+	 *
+	 * @since 5.1.0
+	 * @param array $filters Array of filters.
+	 * @return array
+	 */
+	protected function maybe_change_filter_position( array $filters ): array {
+		$lowercase_filter = array_search( 'lowercase', $filters, true );
+
+		if ( false !== $lowercase_filter ) {
+			unset( $filters[ $lowercase_filter ] );
+			array_unshift( $filters, 'lowercase' );
+		}
+
+		return $filters;
 	}
 }


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask!

If you're not an Automattician, welcome! We look forward to your contribution! :heart:
-->
## Description
<!--
A few sentences describing the overall goals of the Pull Request.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links :)

If the change can be of benefit to upstream, please PR there as well: https://github.com/10up/ElasticPress.
If it's VIP-specific, please denote with a comment prefixed by "VIP: " explaining the why behind the discrepancy.
i.e. "// VIP: Removed block where advanced pagination cannot not be used with nobulk"
-->

The ep_synonyms_filter in the index settings is being added first before the lowercase filter, causing case-sensitive matching to applied to synonyms. Using the `_settings` endpoint on the ES index is showing this:
```
"default": {
	"filter": [
		"ep_synonyms_filter",
		"lowercase",
		"stop",
		"ewp_snowball"
	],
```
when it should be showing this
```
"default": {
	"filter": [
		"lowercase",
		"ep_synonyms_filter",
		"stop",
		"ewp_snowball"
	],
```
This has been fixed in the 10up ElasticPress codebase. https://github.com/10up/ElasticPress/blob/develop/includes/classes/Feature/Search/Synonyms.php#L895

## Checklist

Please make sure the items below have been covered before requesting a review:

- [X] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
