### PR TITLE
Optimize mb_strlen calls during sync process

### DIFF
--- a/includes/classes/Indexable.php
+++ b/includes/classes/Indexable.php
@@ -490,9 +490,9 @@ abstract class Indexable {
 
 		$results = [];
 
-		$body = [];
-
-		$requests = 0;
+		$body              = [];
+		$current_body_size = 0;
+		$requests          = 0;
 
 		/*
 		 * This script will use two main arrays: $body and $documents, being $body the
@@ -501,14 +501,16 @@ abstract class Indexable {
 		 * a buffer as small as possible.
 		 */
 		do {
-			$next_document = array_shift( $documents );
+			$next_document          = array_shift( $documents );
+			$next_document_size     = mb_strlen( $next_document );
+			$has_buffered_documents = count( $body ) > 0;
 
 			// If the next document alone takes the entire current buffer size,
 			// let's add it back to the pipe and send what we have first
-			if ( mb_strlen( $next_document ) > $current_buffer_size && count( $body ) > 0 ) {
+			if ( $next_document_size > $current_buffer_size && $has_buffered_documents ) {
 				array_unshift( $documents, $next_document );
 			} else {
-				if ( mb_strlen( $next_document ) > $max_buffer_size ) {
+				if ( $next_document_size > $max_buffer_size ) {
 					/**
 					 * Perform actions when a post is bigger than the max buffer size.
 					 *
@@ -520,13 +522,20 @@ abstract class Indexable {
 					$results[] = new \WP_Error( 'ep_too_big_request_skipped', 'Indexable too big. Request not sent.' );
 					continue;
 				}
-				$body[] = $next_document;
-				if ( mb_strlen( implode( '', $body ) ) < $current_buffer_size && ! empty( $documents ) ) {
+
+				$body[]             = $next_document;
+				$current_body_size += $next_document_size;
+
+				$can_add_more_documents = ( $current_body_size < $current_buffer_size && ! empty( $documents ) );
+				if ( $can_add_more_documents ) {
 					continue;
 				}
-				if ( mb_strlen( implode( '', $body ) ) > $max_buffer_size ) {
+
+				if ( $current_body_size > $max_buffer_size ) {
 					// The last document added to body made it too big, so let's give it back.
-					array_unshift( $documents, array_pop( $body ) );
+					$removed_document   = array_pop( $body );
+					$current_body_size -= mb_strlen( $removed_document );
+					array_unshift( $documents, $removed_document );
 				}
 			}
 
@@ -553,35 +562,40 @@ abstract class Indexable {
 
 			// It failed, possibly adjust the buffer size and try again.
 			if ( is_wp_error( $result ) ) {
+				$error_code = $result->get_error_code();
+
 				// Too many requests, wait and try again.
-				if ( 429 === $result->get_error_code() ) {
+				if ( 429 === $error_code ) {
 					sleep( 2 );
 				}
 
 				// If the error is not a "Request too big" then we really fail this batch of documents.
-				if ( 413 !== $result->get_error_code() ) {
+				if ( 413 !== $error_code ) {
 					$results[] = $result;
 					continue;
 				}
 
 				if ( count( $body ) === 1 ) {
-					$max_buffer_size = min( $max_buffer_size, mb_strlen( implode( '', $body ) ) );
-					$results[]       = $result;
-					$body            = [];
+					$max_buffer_size   = min( $max_buffer_size, $current_body_size );
+					$results[]         = $result;
+					$body              = [];
+					$current_body_size = 0;
 					continue;
 				}
 
 				// As the buffer is as small as possible, return the error.
-				if ( mb_strlen( implode( '', $body ) ) === $min_buffer_size ) {
+				if ( $current_body_size === $min_buffer_size ) {
 					$results[] = $result;
 					continue;
 				}
 
 				// We have a too big buffer. Remove one doc from the body, and set both max and current as its size.
-				array_unshift( $documents, array_pop( $body ) );
+				$removed_document   = array_pop( $body );
+				$current_body_size -= mb_strlen( $removed_document );
+				array_unshift( $documents, $removed_document );
 
 				$max_buffer_size = count( $body ) ?
-					max( $min_buffer_size, mb_strlen( implode( '', $body ) ) ) :
+					max( $min_buffer_size, $current_body_size ) :
 					$min_buffer_size;
 
 				$current_buffer_size = $max_buffer_size;
@@ -589,13 +603,14 @@ abstract class Indexable {
 			}
 
 			// Things worked so we can try to bump the buffer size.
-			if ( $current_buffer_size < $max_buffer_size && mb_strlen( implode( '', $body ) ) > $current_buffer_size ) {
+			if ( $current_buffer_size < $max_buffer_size && $current_body_size > $current_buffer_size ) {
 				$current_buffer_size = min( ( $current_buffer_size + $incremental_step ), $max_buffer_size );
 			}
 
 			$results[] = $result;
 
-			$body = [];
+			$body              = [];
+			$current_body_size = 0;
 		} while ( ! empty( $documents ) );
 
 		/**

--- a/tests/php/indexables/TestTerm.php
+++ b/tests/php/indexables/TestTerm.php
@@ -1534,7 +1534,7 @@ class TestTerm extends BaseTestCase {
 
 		$results = $term_indexable->query_db(
 			[
-				'taxonomy' => 'post_tag',
+				'taxonomy'     => 'post_tag',
 				'cache_buster' => wp_generate_uuid4(),
 			]
 		);


### PR DESCRIPTION
## Description

This pulls an improvement made upstream: https://github.com/10up/ElasticPress/pull/4304

Optimize `mb_strlen` calls during sync process

## Checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally (or has an appropriate fallback).
- [ ] This change works and has been tested on a Go sandbox.
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] This change has the fix PRed upstream (if applicable). If not applicable, it has the relevant "// VIP: reason for the discrepancy with upstream" comment in places where the code is discrepant.

## Steps to Test
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->
